### PR TITLE
Fixing tags for if mib

### DIFF
--- a/profiles/kentik_snmp/_general/if-mib.yml
+++ b/profiles/kentik_snmp/_general/if-mib.yml
@@ -50,11 +50,11 @@ metrics:
   - column:
       OID: 1.3.6.1.2.1.31.1.1.1.1
       name: ifName
-      tag: interface_name
+    tag: interface_name
   - column:
       OID: 1.3.6.1.2.1.31.1.1.1.18
       name: ifAlias
-      tag: interface_alias
+    tag: interface_alias
 - MIB: IF-MIB
   table:
     OID: 1.3.6.1.2.1.31.1.1


### PR DESCRIPTION
This one fixes a typo where 2 tags in IF-MIB didn't get picked up. 