### PR TITLE
Move disk and interface metrics to use 64bit OIDs

### DIFF
--- a/profiles/kentik_snmp/netapp/netapp-cluster.yml
+++ b/profiles/kentik_snmp/netapp/netapp-cluster.yml
@@ -3,27 +3,32 @@
 extends:
   - system-mib.yml
 
+provider: kentik-nas
+
 sysobjectid: 1.3.6.1.4.1.789.2.5
 
 metrics:
   - MIB: NETAPP-MIB
-    table:
-      OID: 1.3.6.1.4.1.789.1.2
-      name: sysStat
-    symbols:
-      - OID: 1.3.6.1.4.1.789.1.2.3.8
-        name: cfInterconnectStatus
-        enum:
-          notPresent: 1
-          down: 2
-          partialFailure: 3
-          up: 4
-      - OID: 1.3.6.1.4.1.789.1.2.2.23.0
-        name: miscCacheAge
-      - OID: 1.3.6.1.4.1.789.1.8.3.6.36
-        name: ncHttpActiveCliConns
-      - OID: 1.3.6.1.4.1.789.1.26.8
-        name: extcache64Hits
+    symbol:
+      OID: 1.3.6.1.4.1.789.1.2.3.8
+      name: cfInterconnectStatus
+      enum:
+        notPresent: 1
+        down: 2
+        partialFailure: 3
+        up: 4
+  - MIB: NETAPP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.789.1.2.2.23.0
+      name: miscCacheAge
+  - MIB: NETAPP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.789.1.8.3.6.36
+      name: ncHttpActiveCliConns
+  - MIB: NETAPP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.789.1.26.8
+      name: extcache64Hits
   - MIB: NETAPP-MIB
     table:
       OID: 1.3.6.1.4.1.789.1.19.11
@@ -59,20 +64,6 @@ metrics:
     symbols:
       - OID: 1.3.6.1.4.1.789.1.9.20.1.6
         name: snapmirrorLag
-    metric_tags:
-      - tag: snapmirror_index
-        column:
-          OID: 1.3.6.1.4.1.789.1.9.20.1.1
-          name: snapmirrorIndex
-      - tag: snapmirror_state
-        column:
-          OID: 1.3.6.1.4.1.789.1.9.20.1.5
-          name: snapmirrorState
-  - MIB: NETAPP-MIB
-    table:
-      OID: 1.3.6.1.4.1.789.1.9.20
-      name: snapmirrorStatusTable
-    symbols:
       - OID: 1.3.6.1.4.1.789.1.9.20.1.9
         name: snapmirrorTotalFailures
     metric_tags:
@@ -89,10 +80,10 @@ metrics:
       OID: 1.3.6.1.4.1.789.1.5.4
       name: dfTable
     symbols:
-      - OID: 1.3.6.1.4.1.789.1.5.4.1.14
-        name: dfHighTotalKBytes
-      - OID: 1.3.6.1.4.1.789.1.5.4.1.18
-        name: dfHighAvailKBytes
+      - OID: 1.3.6.1.4.1.789.1.5.4.1.29
+        name: df64TotalKBytes
+      - OID: 1.3.6.1.4.1.789.1.5.4.1.31
+        name: df64AvailKBytes
       - OID: 1.3.6.1.4.1.789.1.5.4.1.7
         name: dfInodesUsed
       - OID: 1.3.6.1.4.1.789.1.5.4.1.8
@@ -111,8 +102,8 @@ metrics:
       OID: 1.3.6.1.4.1.789.1.22.1.2
       name: netifTable
     symbols:
-      - OID: 1.3.6.1.4.1.789.1.22.1.2.1.3
-        name: ifHighInOctets
+      - OID: 1.3.6.1.4.1.789.1.22.1.2.1.25
+        name: if64InOctets
     metric_tags:
       - tag: network_interface_index
         column:


### PR DESCRIPTION
The disk partitions were only recording the oid for dfHighTotalKBytes, which only makes sense if the partitions are at least 2TB in size, otherwise they'll always report 0. Move them to the full 64bit OID, so that small partitions are also recorded.

Similarly move the network interface stats to use a 64bit OID, so that traffic on low usage interfaces appears.

Also, some tidying of the entries under sysStat so that they're declared as standalone metrics, and not ones in a table.

Finally set a default "provider" (though I'm not certain if this is an appropriate value).