### PR TITLE
Adding the entity_name to the sensor list for cisco

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-all-devices.yml
+++ b/profiles/kentik_snmp/cisco/cisco-all-devices.yml
@@ -76,8 +76,11 @@ metrics:
       - OID: 1.3.6.1.4.1.9.9.91.1.1.1.1.8
         name: entSensorMeasuredEntity
     metric_tags:
-      - index: 1
-        tag: sensor_id
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.7
+          name: entPhysicalName
+        tag: entity_name
+
   - MIB: CISCO-ENTITY-SENSOR-MIB
     table:
       OID: 1.3.6.1.4.1.9.9.91.1.2.1


### PR DESCRIPTION
This brings `entity_name` over to the sensor list for cisco. Trying to fix https://github.com/kentik/ktranslate/issues/162

Testing on a cat switch, it does what the user expects. 