### PR TITLE
Fix generic net snmp

### DIFF
--- a/profiles/kentik_snmp/_general/bgp4-mib.yml
+++ b/profiles/kentik_snmp/_general/bgp4-mib.yml
@@ -1,3 +1,4 @@
+# Profile is intended to be used in an extends block
 # http://oid-info.com/get/1.3.6.1.2.1.15.3
 ---
 metrics:

--- a/profiles/kentik_snmp/_general/host-resources-mib.yml
+++ b/profiles/kentik_snmp/_general/host-resources-mib.yml
@@ -1,3 +1,4 @@
+# Profile is intended to be used in an extends block
 # http://oid-info.com/get/1.3.6.1.2.1.25
 ---
 metrics:

--- a/profiles/kentik_snmp/_general/if-mib.yml
+++ b/profiles/kentik_snmp/_general/if-mib.yml
@@ -1,3 +1,4 @@
+# Profile is intended to be used in an extends block
 # http://oid-info.com/get/1.3.6.1.2.1.2.2
 # http://oid-info.com/get/1.3.6.1.2.1.31
 metrics:

--- a/profiles/kentik_snmp/_general/ip-mib.yml
+++ b/profiles/kentik_snmp/_general/ip-mib.yml
@@ -1,3 +1,4 @@
+# Profile is intended to be used in an extends block
 # http://oid-info.com/get/1.3.6.1.2.1.4.31
 ---
 metrics:

--- a/profiles/kentik_snmp/_general/net-snmp.yml
+++ b/profiles/kentik_snmp/_general/net-snmp.yml
@@ -1,0 +1,17 @@
+# This profile matches on the generic Linux SysOID
+# https://oidref.com/1.3.6.1.4.1.8072.3.2.10
+---
+extends:
+  - host-resources-mib.yml
+  - if-mib.yml
+  - system-mib.yml
+  - ucd-mib.yml
+  - dell-poweredge.yml
+
+provider: kentik-net-snmp
+
+# disable the SNMP bulk walk operation for these devices
+no_use_bulkwalkall: true
+
+sysobjectid:
+  - 1.3.6.1.4.1.8072.*

--- a/profiles/kentik_snmp/_general/ospf-mib.yml
+++ b/profiles/kentik_snmp/_general/ospf-mib.yml
@@ -1,3 +1,4 @@
+# Profile is intended to be used in an extends block
 # http://oid-info.com/get/1.3.6.1.2.1.14
 ---
 metrics:

--- a/profiles/kentik_snmp/_general/system-mib.yml
+++ b/profiles/kentik_snmp/_general/system-mib.yml
@@ -1,3 +1,4 @@
+# Profile is intended to be used in an extends block
 # http://oid-info.com/get/1.3.6.1.2.1.1
 ---
 metric_tags:

--- a/profiles/kentik_snmp/_general/tcp-mib.yml
+++ b/profiles/kentik_snmp/_general/tcp-mib.yml
@@ -1,3 +1,4 @@
+# Profile is intended to be used in an extends block
 # http://oid-info.com/get/1.3.6.1.2.1.6
 ---
 metrics:

--- a/profiles/kentik_snmp/_general/ucd-mib.yml
+++ b/profiles/kentik_snmp/_general/ucd-mib.yml
@@ -1,4 +1,5 @@
-# Alternative MIB for host-resources-mib used on some older devices
+# Profile is intended to be used in an extends block
+# Alternative MIB for host-resources-mib used on some devices
 # http://oid-info.com/get/1.3.6.1.4.1.2021
 
 metrics:

--- a/profiles/kentik_snmp/_general/udp-mib.yml
+++ b/profiles/kentik_snmp/_general/udp-mib.yml
@@ -1,3 +1,4 @@
+# Profile is intended to be used in an extends block
 # http://oid-info.com/get/1.3.6.1.2.1.7
 ---
 metrics:

--- a/profiles/kentik_snmp/dell/dell-poweredge.yml
+++ b/profiles/kentik_snmp/dell/dell-poweredge.yml
@@ -1,17 +1,5 @@
 # https://www.circitor.fr/Mibs/Html/M/MIB-Dell-10892.php
-# This profile matches on the generic Linux SysOID
-# https://oidref.com/1.3.6.1.4.1.8072.3.2.10
 ---
-extends:
-  - system-mib.yml
-
-provider: kentik-physical-server
-
-# disable the SNMP bulk walk operation for these devices
-no_use_bulkwalkall: true
-
-sysobjectid:
-  - 1.3.6.1.4.1.8072.3.2.10
 
 metrics:
   # operatingSystemMemoryTable

--- a/profiles/kentik_snmp/dell/dell-poweredge.yml
+++ b/profiles/kentik_snmp/dell/dell-poweredge.yml
@@ -1,3 +1,4 @@
+# Profile is intended to be used in an extends block
 # https://www.circitor.fr/Mibs/Html/M/MIB-Dell-10892.php
 ---
 


### PR DESCRIPTION
Created net-snmp profile in _general that just extends out the expected standard plus the dell specific mib.  As we come across walks for other hardware vendors we can add them in later.  
I expect we would also do something similar for the windows snmp sysOID.

Still open on what to call the entity type, matching against this sysOID will get us anything running net-snmp, could be a physical server, virtual server, appliance that didn't bother to update to their own MIBs, technically even windows boxes could return this if someone was motivated enough to disabled the native windows snmp agent and instead used the net-snmp binaries.

I know we talked about having capabilities to parse these out further down the line but this is what we have in the mean time.