### PR TITLE
feat: initial upload of trap config for eaton vdc

### DIFF
--- a/profiles/kentik_snmp/eaton/traps.yml
+++ b/profiles/kentik_snmp/eaton/traps.yml
@@ -5,6 +5,7 @@ traps:
   # Traps from Visual Data Center (VDC), formerly owned by Optimum Path
   - trap_oid: 1.3.6.1.4.1.34510.2.1.1.6.1
     trap_name: vdcAlarms
+    drop_undefined: true
     events:
       - name: vdcAlarmId
         OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.1

--- a/profiles/kentik_snmp/eaton/traps.yml
+++ b/profiles/kentik_snmp/eaton/traps.yml
@@ -1,0 +1,22 @@
+# Eaton vendor traps definition
+---
+
+traps:
+  # Traps from Visual Data Center (VDC), formerly owned by Optimum Path
+  - trap_oid: 1.3.6.1.4.1.34510.2.1.1.6.1
+    trap_name: vdcAlarms
+    events:
+      - name: vdcAlarmId
+        OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.1
+      - name: vdcAlarmDesc
+        OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.2
+      - name: vdcAlarmTime
+        OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.3
+      - name: vdcLevel
+        OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.4
+      - name: vdcDevice
+        OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.5
+      - name: vdcMonAttrib
+        OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.6
+      - name: vdcProbeId
+        OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.7


### PR DESCRIPTION
should align with [PR 187 on ktranslate](https://github.com/kentik/ktranslate/pull/187)

address Issue #44 

Sample Trap Message (sanitized) from packet capture:

```
1.3.6.1.2.1.1.3.0: 0
1.3.6.1.6.3.1.1.4.1.0: 1.3.6.1.4.1.34510.2.1.1.6.1 (iso.3.6.1.4.1.34510.2.1.1.6.1)
1.3.6.1.4.1.34510.2.1.1.3.2.1.1: "c46xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
1.3.6.1.4.1.34510.2.1.1.3.2.1.2: "Temperature : Reachable"
1.3.6.1.4.1.34510.2.1.1.3.2.1.3: 1637046573
1.3.6.1.4.1.34510.2.1.1.3.2.1.4: 1
1.3.6.1.4.1.34510.2.1.1.3.2.1.5: "Device_Name"
1.3.6.1.4.1.34510.2.1.1.3.2.1.6: "Temperature"
1.3.6.1.4.1.34510.2.1.1.3.2.1.7: "e32xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
1.3.6.1.4.1.34510.2.1.1.3.2.1.8: "SP10.xxx.xxx.xxx"
1.3.6.1.4.1.34510.2.1.1.3.2.1.9: "10.xxx.xxx.xxx"
1.3.6.1.4.1.34510.2.1.1.3.2.1.10: <MISSING>
1.3.6.1.4.1.34510.2.1.1.3.2.1.11: "Data Center"
1.3.6.1.4.1.34510.2.1.1.3.2.1.12: <MISSING>
1.3.6.1.4.1.34510.2.1.1.3.2.1.13: "Country, State, City, Address, Physical Location"
```