### PR TITLE
include cisco-all-devices

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-asr.yml
+++ b/profiles/kentik_snmp/cisco/cisco-asr.yml
@@ -7,6 +7,7 @@ extends:
   - if-mib.yml
   - ospf-mib.yml
   - system-mib.yml
+  - cisco-all-devices.yml
 
 provider: kentik-router
 


### PR DESCRIPTION
local cpu and memory tags should over ride the ones from the extend