### PR TITLE
chore: Improve CPU collection

### DIFF
--- a/profiles/kentik_snmp/_general/ucd-mib.yml
+++ b/profiles/kentik_snmp/_general/ucd-mib.yml
@@ -79,37 +79,9 @@ metrics:
           name: dskErrorMsg
   - MIB: UCD-SNMP-MIB
     symbol:
-      OID: 1.3.6.1.4.1.2021.10.1.5.1
-      name: laLoadInt1Min
+      OID: 1.3.6.1.4.1.2021.10.1.3.1
+      name: laLoad1Min
       tag: CPU
-  - MIB: UCD-SNMP-MIB
-    table:
-      OID: 1.3.6.1.4.1.2021.10
-      name: laTable
-    symbols:
-      - OID: 1.3.6.1.4.1.2021.10.1.3
-        name: laLoad
-      - OID: 1.3.6.1.4.1.2021.10.1.4
-        name: laConfig
-      - OID: 1.3.6.1.4.1.2021.10.1.5
-        name: laLoadInt
-      - OID: 1.3.6.1.4.1.2021.10.1.6
-        name: laLoadFloat
-      - OID: 1.3.6.1.4.1.2021.10.1.100
-        name: laErrorFlag
-    metric_tags:
-      - tag: la_index
-        column:
-          OID: 1.3.6.1.4.1.2021.10.1.1
-          name: laIndex
-      - tag: la_names
-        column:
-          OID: 1.3.6.1.4.1.2021.10.1.2
-          name: laNames
-      - tag: la_error_message
-        column:
-          OID: 1.3.6.1.4.1.2021.10.1.101
-          name: laErrMessage
   - MIB: UCD-SNMP-MIB
     symbol:
       OID: 1.3.6.1.4.1.2021.11.3.0


### PR DESCRIPTION
Looking at live data from a device it is pretty clear that we don't need all the extra columns of stuff, only 1 min average is valuable for us and we should use the laLoad value instead of laLoadInt