### PR TITLE
chore: extend include ip-yml

### DIFF
--- a/profiles/kentik_snmp/_general/net-snmp.yml
+++ b/profiles/kentik_snmp/_general/net-snmp.yml
@@ -4,6 +4,7 @@
 extends:
   - host-resources-mib.yml
   - if-mib.yml
+  - ip.yml
   - system-mib.yml
   - ucd-mib.yml
   - dell-poweredge.yml


### PR DESCRIPTION
since we have had net-snmp devices being used as routers this will potentially come in handy