### PR TITLE
feat: adding rv340 to cisco router profile

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-asr.yml
+++ b/profiles/kentik_snmp/cisco/cisco-asr.yml
@@ -92,6 +92,7 @@ sysobjectid:
   - 1.3.6.1.4.1.9.1.2678  # Cisco 92012SZD ASR
   - 1.3.6.1.4.1.9.1.2679  # Cisco 92012SZA ASR
   - 1.3.6.1.4.1.9.1.2705  # Cisco 92020SZM ASR
+  - 1.3.6.1.4.1.9.6.1.23.3.13.0.4  # Cisco RV340 Dual WAN Gigabit VPN Router
 
 metrics:
   - MIB: CISCO-PROCESS-MIB


### PR DESCRIPTION
adding to pre-existing cisco router profile as it doesn't quite fit the "firewall" category based on [Cisco's docs](https://www.cisco.com/c/en/us/products/routers/rv340-dual-gigabit-wan-vpn-router/index.html); resolves Issue #66 

