### PR TITLE
Feat/aruba 2930f

### DIFF
--- a/profiles/kentik_snmp/aruba/aruba-switch.yml
+++ b/profiles/kentik_snmp/aruba/aruba-switch.yml
@@ -1,0 +1,56 @@
+# http://www.circitor.fr/Mibs/Html/S/STATISTICS-MIB.php
+# https://mibs.observium.org/mib/NETSWITCH-MIB/
+# https://mibs.observium.org/mib/POWER-ETHERNET-MIB/
+---
+extends:
+  - if-mib.yml
+  - ip-mib.yml
+  - system-mib.yml
+  - tcp-mib.yml
+
+profile: kentik-switch
+
+sysobjectid:
+  - 1.3.6.1.4.1.11.2.3.7.11.181.21    # JL256A/2930F
+
+metrics:
+  - MIB: STATISTICS-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.11.2.14.11.5.1.9.6.1.0
+      name: hpSwitchCpuStat
+      tag: CPU
+  - MIB: NETSWITCH-MIB
+    table:
+      OID: 1.3.6.1.4.1.11.2.14.11.5.1.1.2.1.1
+      name: hpLocalMemTable
+    symbols:
+      - OID: 1.3.6.1.4.1.11.2.14.11.5.1.1.2.1.1.1.5
+        name: hpLocalMemTotalBytes
+        tag: MemoryTotal
+      - OID: 1.3.6.1.4.1.11.2.14.11.5.1.1.2.1.1.1.6
+        name: hpLocalMemFreeBytes
+        tag: MemoryFree
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.11.2.14.11.5.1.1.2.1.1.1.1
+          name: hpLocalMemSlotIndex
+  - MIB: POWER-ETHERNET-MIB
+    table:
+      OID: 1.3.6.1.2.1.105.1.3
+      name: pethMainPseTable
+    symbols:
+      - OID: 1.3.6.1.2.1.105.1.3.1.1.2
+        name: pethMainPsePower
+      - OID: 1.3.6.1.2.1.105.1.3.1.1.4
+        name: pethMainPseConsumptionPower
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.2.1.105.1.3.1.1.1
+          name: pethMainPseGroupIndex
+      - column:
+          OID: 1.3.6.1.2.1.105.1.3.1.1.3
+          name: pethMainOperStatus
+          enum: 
+            on: 1
+            off: 2
+            faulty: 3

--- a/profiles/kentik_snmp/aruba/aruba-switch.yml
+++ b/profiles/kentik_snmp/aruba/aruba-switch.yml
@@ -6,7 +6,6 @@ extends:
   - if-mib.yml
   - ip-mib.yml
   - system-mib.yml
-  - tcp-mib.yml
 
 profile: kentik-switch
 

--- a/profiles/kentik_snmp/aruba/aruba-wireless-controller.yml
+++ b/profiles/kentik_snmp/aruba/aruba-wireless-controller.yml
@@ -5,6 +5,8 @@ extends:
   - if-mib.yml
   - ospf-mib.yml
 
+profile: kentik-wireless-controller
+
 sysobjectid: 1.3.6.1.4.1.14823.*
 
 metrics:


### PR DESCRIPTION
adding new aruba switch profile from info in issue #71; also moved existing `aruba.yml` >> `aruba-wireless-controller.yml` 