### PR TITLE
Fixing typo in the net-snmp profile

### DIFF
--- a/profiles/kentik_snmp/_general/net-snmp.yml
+++ b/profiles/kentik_snmp/_general/net-snmp.yml
@@ -4,7 +4,7 @@
 extends:
   - host-resources-mib.yml
   - if-mib.yml
-  - ip.yml
+  - ip-mib.yml
   - system-mib.yml
   - ucd-mib.yml
   - dell-poweredge.yml


### PR DESCRIPTION
This is throwing this error in logs:

```
2021-12-02T14:23:56.527 ktranslate(127544) [Error] KTranslate You must set the ip.yml extended profile.
```