### PR TITLE
feat: adding powerconnect 3548 profile

### DIFF
--- a/profiles/kentik_snmp/dell/dell-powerconnect.yml
+++ b/profiles/kentik_snmp/dell/dell-powerconnect.yml
@@ -1,0 +1,18 @@
+# https://mibs.observium.org/mib/RADLAN-MIB/
+# Memory Utilization not available on the 3548 device
+---
+extends:
+  - system-mib.yml
+  - if-mib.yml
+
+provider: kentik-switch
+
+sysobjectid:
+  - 1.3.6.1.4.1.674.10895.3017    # PowerConnect 3548
+
+metrics:
+  - MIB: RADLAN-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.89.1.8.0
+      name: rlCpuUtilDuringLastMinute
+      tag: CPU


### PR DESCRIPTION
address issue #93 

*NOTE: Memory Utilization metrics are not available via SNMP on this device. Confirmed via both provided SNMP walk and Dell forums.*