### PR TITLE
chore: splitting H3C and ICF switches for CPU/Mem

### DIFF
--- a/profiles/kentik_snmp/hp/hp-h3c-switch.yml
+++ b/profiles/kentik_snmp/hp/hp-h3c-switch.yml
@@ -11,8 +11,7 @@ extends:
 provider: kentik-switch
 
 sysobjectid:
-  - 1.3.6.1.4.1.25506.11.1.*    # HPE Switches
-  - 1.3.6.1.4.1.11.2.3.7.11.*   # http://oid-info.com/get/1.3.6.1.4.1.11.2.3.7.11
+  - 1.3.6.1.4.1.25506.11.1.*    # H3C Switches
 
 metrics:
   # CPU Utilization for all running processes

--- a/profiles/kentik_snmp/hp/hp-icf-switch.yml
+++ b/profiles/kentik_snmp/hp/hp-icf-switch.yml
@@ -1,0 +1,35 @@
+# https://mibs.observium.org/mib/HP-ICF-OID/
+# https://mibs.observium.org/mib/STATISTICS-MIB/
+# https://mibs.observium.org/mib/NETSWITCH-MIB/
+---
+
+extends:
+  - system-mib.yml
+  - if-mib.yml
+
+provider: kentik-switch
+
+sysobjectid:
+  - 1.3.6.1.4.1.11.2.3.7.11.*    # Covers a wide range of both HP and Aruba switches
+
+metrics:
+  # The CPU utilization in percent(%)
+  - MIB: STATISTICS-MIB
+    symbol:
+      name: hpSwitchCpuStat
+      OID: 1.3.6.1.4.1.11.2.14.11.5.1.9.6.1
+      tag: CPU
+  # A table that contains information on all the local memory for each slot
+  - MIB: NETSWITCH-MIB
+    table:
+      name: hpLocalMemTable
+      OID: 1.3.6.1.4.1.11.2.14.11.5.1.1.2.1.1
+    symbols:
+      # The number of currently installed bytes
+      - name: hpLocalMemTotalBytes
+        OID: 1.3.6.1.4.1.11.2.14.11.5.1.1.2.1.1.1.5
+        tag: MemoryTotal
+      # The number of available (unallocated) bytes
+      - name: hpLocalMemFreeBytes
+        OID: 1.3.6.1.4.1.11.2.14.11.5.1.1.2.1.1.1.6
+        tag: MemoryFree


### PR DESCRIPTION
addresses findings in issue #105 

moves ICF switches to their own profile to collect CPU and Memory on dedicated OIDs from the `STATISTICS` and `NETSWITCH` MIBs