### PR TITLE
Tweaking barracuda to make match

### DIFF
--- a/profiles/kentik_snmp/barracuda/barracuda-email-gateway.yml
+++ b/profiles/kentik_snmp/barracuda/barracuda-email-gateway.yml
@@ -10,6 +10,9 @@ extends:
 
 profile: kentik-barracuda-email-gateway
 
+sysobjectid:
+  - 1.3.6.1.4.1.8072.3.2.10.barracuda
+
 metrics:
   # Spam in queue size
   - MIB: BARRACUDA-SPAM-MIB

--- a/profiles/kentik_snmp/synology/disk_station.yml
+++ b/profiles/kentik_snmp/synology/disk_station.yml
@@ -32,14 +32,18 @@ metrics:
         name: laLoadInt1
         poll_time_sec: 60
         tag: CPU
-      - OID: 1.3.6.1.4.1.2021.4.5.0
-        name: memTotalReal
-        poll_time_sec: 60
+      - OID: 1.3.6.1.2.1.25.2.3.1.6.1
+        name: hrStorageUsed
         tag: MemoryTotal
-      - OID: 1.3.6.1.4.1.2021.4.11.0
-        name: memTotalFree
         poll_time_sec: 60
-        tag: MemoryFree
+      - OID: 1.3.6.1.2.1.25.2.3.1.6.6
+        name: hrStorageUsed
+        tag: MemoryBuffer
+        poll_time_sec: 60
+      - OID: 1.3.6.1.2.1.25.2.3.1.6.7
+        name: hrStorageUsed
+        tag: MemoryCache
+        poll_time_sec: 60
     metric_tags:
       - column:
           OID: 1.3.6.1.4.1.6574.1.5.1


### PR DESCRIPTION
Fix for https://github.com/kentik/ktranslate/issues/221

To be a valid profile, there needs to be at least 1 sysobjectid defined for a device. This updates the kentik-barracuda-email-gateway profile with a fake sysobjectid so that when it gets matched by the sysdesc in net-snmp there's a valid profile to add in. 

Look for a log line like:

```
[Error] KTranslate No profile matching barracuda-email-gateway.yml found
```

If there's another profile which isn't working based on sysdesc. 

Also small tweak for synology to get better memory stats. 