### PR TITLE
Fix missing interface_name

### DIFF
--- a/profiles/kentik_snmp/_general/ip-mib.yml
+++ b/profiles/kentik_snmp/_general/ip-mib.yml
@@ -145,4 +145,4 @@ metrics:
         4: ipv6z
         16: dns
     - index: 2
-      tag: if_interface_name
+      tag: interface_name

--- a/profiles/kentik_snmp/_general/ip-mib.yml
+++ b/profiles/kentik_snmp/_general/ip-mib.yml
@@ -145,4 +145,4 @@ metrics:
         4: ipv6z
         16: dns
     - index: 2
-      tag: interface_name
+      tag: if_interface_name

--- a/profiles/kentik_snmp/cisco/cisco-all-devices.yml
+++ b/profiles/kentik_snmp/cisco/cisco-all-devices.yml
@@ -31,7 +31,7 @@ metrics:
         poll_time_sec: 60
         tag: CPU
     metric_tags:
-      - column: 
+      - column:
           OID: 1.3.6.1.4.1.9.9.109.1.1.1.1.1
           name: cpmCPUTotalIndex
         tag: cpu_index
@@ -67,7 +67,7 @@ metrics:
         column:
           OID: 1.3.6.1.2.1.31.1.1.1.1
           name: ifName
-        tag: interface_name
+        tag: if_interface_name
   - MIB: CISCO-STACKWISE-MIB
     table:
       OID: 1.3.6.1.4.1.9.9.500.1.2.2
@@ -83,7 +83,7 @@ metrics:
       - column:
           OID: 1.3.6.1.2.1.31.1.1.1.1
           name: ifName
-        tag: interface_name
+        tag: if_interface_name
   - MIB: CISCO-STACKWISE-MIB
     table:
       OID: 1.3.6.1.4.1.9.9.500.1.2.1
@@ -167,8 +167,8 @@ metrics:
             fan: 7
             sensor: 8
             module: 9
-            port: 10 
-            stack: 11 
+            port: 10
+            stack: 11
             cpu: 12
         tag: entity_class
       - column:
@@ -235,8 +235,8 @@ metrics:
             fan: 7
             sensor: 8
             module: 9
-            port: 10 
-            stack: 11 
+            port: 10
+            stack: 11
             cpu: 12
         tag: entity_class
       - column:
@@ -352,8 +352,8 @@ metrics:
             fan: 7
             sensor: 8
             module: 9
-            port: 10 
-            stack: 11 
+            port: 10
+            stack: 11
             cpu: 12
         tag: entity_class
       - column:
@@ -402,8 +402,8 @@ metrics:
             fan: 7
             sensor: 8
             module: 9
-            port: 10 
-            stack: 11 
+            port: 10
+            stack: 11
             cpu: 12
         tag: entity_class
       - column:
@@ -449,8 +449,8 @@ metrics:
             fan: 7
             sensor: 8
             module: 9
-            port: 10 
-            stack: 11 
+            port: 10
+            stack: 11
             cpu: 12
         tag: entity_class
       - column:
@@ -494,8 +494,8 @@ metrics:
             fan: 7
             sensor: 8
             module: 9
-            port: 10 
-            stack: 11 
+            port: 10
+            stack: 11
             cpu: 12
         tag: entity_class
       - column:
@@ -788,12 +788,12 @@ metrics:
         tag: rtt_operation_protocol
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.2
-          name: rttMonEchoAdminTargetAddress 
+          name: rttMonEchoAdminTargetAddress
 #          conversion: hex_octet
         tag: rtt_echo_target_ip
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.5
-          name: rttMonEchoAdminTargetPort 
+          name: rttMonEchoAdminTargetPort
 #          conversion: hex_octet
         tag: rtt_echo_target_port
       - column:

--- a/profiles/kentik_snmp/cisco/cisco-catalyst.yml
+++ b/profiles/kentik_snmp/cisco/cisco-catalyst.yml
@@ -393,4 +393,4 @@ metrics:
           OID: 1.3.6.1.2.1.31.1.1.1.1
           name: ifName
         table: ifXTable
-        tag: interface_name
+        tag: if_interface_name

--- a/profiles/kentik_snmp/cisco/cisco-voice.yml
+++ b/profiles/kentik_snmp/cisco/cisco-voice.yml
@@ -113,7 +113,7 @@ metrics:
           OID: 1.3.6.1.2.1.31.1.1.1.1
           name: ifName
         table: ifXTable
-        tag: interface_name
+        tag: if_interface_name
   - MIB: CISCO-VOICE-DIAL-CONTROL-MIB
     table:
       name: cvCallVolPeerTable

--- a/profiles/kentik_snmp/fortinet/fortinet-fortigate.yml
+++ b/profiles/kentik_snmp/fortinet/fortinet-fortigate.yml
@@ -128,7 +128,7 @@ metrics:
           OID: 1.3.6.1.2.1.31.1.1.1.1
           name: ifName
         table: ifXTable
-        tag: interface_name
+        tag: if_interface_name
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.8.0

--- a/profiles/kentik_snmp/juniper/juniper-ex-switches.yml
+++ b/profiles/kentik_snmp/juniper/juniper-ex-switches.yml
@@ -55,7 +55,7 @@ metrics:
           OID: 1.3.6.1.2.1.31.1.1.1.1
           name: ifName
         table: ifXTable
-        tag: interface_name
+        tag: if_interface_name
         index_transform:
           - start: 0
             end: 0
@@ -197,7 +197,7 @@ metrics:
           OID: 1.3.6.1.4.1.2636.3.15.9.1.2
           name: jnxCosIfsetDescr
         table: jnxCosIfTable
-        tag: interface_name
+        tag: if_interface_name
         index_transform:
           - start: 0
             end: 0
@@ -265,7 +265,7 @@ metrics:
           OID: 1.3.6.1.4.1.2636.3.15.9.1.2
           name: jnxCosIfsetDescr
         table: jnxCosIfTable
-        tag: interface_name
+        tag: if_interface_name
         index_transform:
           - start: 0
             end: 0

--- a/profiles/kentik_snmp/juniper/juniper-ex-switches.yml
+++ b/profiles/kentik_snmp/juniper/juniper-ex-switches.yml
@@ -197,7 +197,7 @@ metrics:
           OID: 1.3.6.1.4.1.2636.3.15.9.1.2
           name: jnxCosIfsetDescr
         table: jnxCosIfTable
-        tag: if_interface_name
+        tag: interface_name
         index_transform:
           - start: 0
             end: 0
@@ -265,7 +265,7 @@ metrics:
           OID: 1.3.6.1.4.1.2636.3.15.9.1.2
           name: jnxCosIfsetDescr
         table: jnxCosIfTable
-        tag: if_interface_name
+        tag: interface_name
         index_transform:
           - start: 0
             end: 0

--- a/profiles/kentik_snmp/juniper/juniper-srx-firewalls.yml
+++ b/profiles/kentik_snmp/juniper/juniper-srx-firewalls.yml
@@ -69,7 +69,7 @@ metrics:
           OID: 1.3.6.1.2.1.31.1.1.1.1
           name: ifName
         table: ifXTable
-        tag: interface_name
+        tag: if_interface_name
         index_transform:
           - start: 0
             end: 0
@@ -95,7 +95,7 @@ metrics:
           OID: 1.3.6.1.2.1.31.1.1.1.1
           name: ifName
         table: ifXTable
-        tag: interface_name
+        tag: if_interface_name
         index_transform:
           - start: 0
             end: 0


### PR DESCRIPTION
I think this should fix https://github.com/kentik/ktranslate/issues/236

Problem is that the table for interface_name was getting confused. I was able to reproduce with a catalyst and this config makes it work again. I apologize for the messy diff, my editor also trimmed off a few empty trailing spaces.

What do you think? 