### PR TITLE
fix/scalar oid fix

### DIFF
--- a/profiles/kentik_snmp/_template.yml
+++ b/profiles/kentik_snmp/_template.yml
@@ -21,7 +21,7 @@ metrics:
   # Scalar OIDs can be directly polled and are individually added to the profile
   - MIB: CISCO-SYSTEM-EXT-MIB                 # The name of the target MIB
     symbol:
-      OID: 1.3.6.1.4.1.9.9.305.1.1.1.0        # The target scalar OID value
+      OID: 1.3.6.1.4.1.9.9.305.1.1.1.0        # The target scalar OID value, this needs to end in an index, usually ".0"
       name: cseSysCPUUtilization              # The target scalar OID name
       poll_time_sec: 60                       # You can force a faster polling interval for specific OID's, especially for Golden Metrics
       tag: CPU                                # OPTIONAL: Used to rename the metric key sent to New Relic

--- a/profiles/kentik_snmp/barracuda/barracuda-email-gateway.yml
+++ b/profiles/kentik_snmp/barracuda/barracuda-email-gateway.yml
@@ -17,110 +17,110 @@ metrics:
   # Spam in queue size
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.2
+      OID: 1.3.6.1.4.1.20632.2.2.0
       name: inQueueSize
   # Spam out queue size
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.3
+      OID: 1.3.6.1.4.1.20632.2.3.0
       name: outQueueSize
   # Spam deferred queue size
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.4
+      OID: 1.3.6.1.4.1.20632.2.4.0
       name: deferredQueueSize
   # Spam avg. email latency
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.5
+      OID: 1.3.6.1.4.1.20632.2.5.0
       name: avgEmailLatency
   # Spam out queue size
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.8
+      OID: 1.3.6.1.4.1.20632.2.8.0
       name: notifyQueueSize
   # Time in minutes since last message was delivered
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.11
+      OID: 1.3.6.1.4.1.20632.2.11.0
       name: lastMessageDelivery
   # Number of unique recipients in last 24 hours
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.12
+      OID: 1.3.6.1.4.1.20632.2.12.0
       name: uniqueRecipients
   # Total number of blocked inbound messages
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.20
+      OID: 1.3.6.1.4.1.20632.2.20.0
       name: totalInboundBlocked
   # Total number of inbound messages blocked containing viruses
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.23
+      OID: 1.3.6.1.4.1.20632.2.23.0
       name: totalInboundVirusBlocked
   # Total number of blocked inbound message connections
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.26
+      OID: 1.3.6.1.4.1.20632.2.26.0
       name: totalInboundRateControlled
   # Total number of inbound messages quarantined
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.29
+      OID: 1.3.6.1.4.1.20632.2.29.0
       name: totalInboundQuarantined
   # Total number of tagged inbound messages
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.32
+      OID: 1.3.6.1.4.1.20632.2.32.0
       name: totalInboundTagged
   # Total number of allowed inbound messages
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.35
+      OID: 1.3.6.1.4.1.20632.2.35.0
       name: totalAllowed
   # Total number of outbound messages blocked due to policy violations
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.38
+      OID: 1.3.6.1.4.1.20632.2.38.0
       name: totalOutboundPolicyBlocked
   # Total number of outbound spam messages
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.41
+      OID: 1.3.6.1.4.1.20632.2.41.0
       name: totalOutboundSpamBlocked
   # Total number of outbound messages blocked containing viruses
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.44
+      OID: 1.3.6.1.4.1.20632.2.44.0
       name: totalOutboundVirusBlocked
   # Total number of blocked outbound message connections
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.47
+      OID: 1.3.6.1.4.1.20632.2.47.0
       name: totalOutboundRateControlled
   # Total number of outbound messages quarantined
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.50
+      OID: 1.3.6.1.4.1.20632.2.50.0
       name: totalOutboundQuarantined
   # Total number of messages encrypted
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.53
+      OID: 1.3.6.1.4.1.20632.2.53.0
       name: totalEncrypted
   # Total number of messages redirected
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.56
+      OID: 1.3.6.1.4.1.20632.2.56.0
       name: totalRedirected
   # Total number of outbound messages allowed
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.59
+      OID: 1.3.6.1.4.1.20632.2.59.0
       name: totalSent
   # Number of inbound domains hosted
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.62
+      OID: 1.3.6.1.4.1.20632.2.62.0
       name: domainCount

--- a/profiles/kentik_snmp/cisco/cisco-voice.yml
+++ b/profiles/kentik_snmp/cisco/cisco-voice.yml
@@ -82,22 +82,22 @@ metrics:
   - MIB: CISCO-VOICE-DIAL-CONTROL-MIB
     symbol:
       name: cvCallRateMonitorEnable
-      OID: 1.3.6.1.4.1.9.9.63.1.3.11.1
+      OID: 1.3.6.1.4.1.9.9.63.1.3.11.1.0
       enum:
         true: 1
         false: 2
   - MIB: CISCO-VOICE-DIAL-CONTROL-MIB
     symbol:
       name: cvCallRateMonitorTime
-      OID: 1.3.6.1.4.1.9.9.63.1.3.11.2
+      OID: 1.3.6.1.4.1.9.9.63.1.3.11.2.0
   - MIB: CISCO-VOICE-DIAL-CONTROL-MIB
     symbol:
       name: cvCallRate
-      OID: 1.3.6.1.4.1.9.9.63.1.3.11.3
+      OID: 1.3.6.1.4.1.9.9.63.1.3.11.3.0
   - MIB: CISCO-VOICE-DIAL-CONTROL-MIB
     symbol:
       name: cvCallRateHiWaterMark
-      OID: 1.3.6.1.4.1.9.9.63.1.3.11.4
+      OID: 1.3.6.1.4.1.9.9.63.1.3.11.4.0
   - MIB: CISCO-VOICE-DIAL-CONTROL-MIB
     table:
       name: cvCallVolIfTable

--- a/profiles/kentik_snmp/cisco/cisco-wlc.yml
+++ b/profiles/kentik_snmp/cisco/cisco-wlc.yml
@@ -66,7 +66,7 @@ metrics:
         activeHandback: 16
   - MIB: CISCO-RF-MIB
     symbol:
-      OID: 1.3.6.1.4.1.9.9.176.1.1.8
+      OID: 1.3.6.1.4.1.9.9.176.1.1.8.0
       name: cRFStatusLastSwactReasonCode
       enum:
         unsupported: 1
@@ -78,11 +78,11 @@ metrics:
         activeUnitRemoved: 7
   - MIB: CISCO-RF-MIB
     symbol:
-      OID: 1.3.6.1.4.1.9.9.176.1.1.9
+      OID: 1.3.6.1.4.1.9.9.176.1.1.9.0
       name: cRFStatusFailoverTime
   - MIB: CISCO-RF-MIB
     symbol:
-      OID: 1.3.6.1.4.1.9.9.176.1.2.16
+      OID: 1.3.6.1.4.1.9.9.176.1.2.16.0
       name: cRFCfgRedundancyOperMode
       enum: 
         nonRedundant: 1

--- a/profiles/kentik_snmp/f5/f5.yml
+++ b/profiles/kentik_snmp/f5/f5.yml
@@ -19,76 +19,76 @@ metrics:
   # This is average usage ratio of CPU for the system in the last one minute (needs to be multiplied by 100 in the NR UI to express percentage)
   - MIB: F5-BIGIP-SYSTEM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.3375.2.1.1.2.20.29
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.20.29.0
       name: sysGlobalHostCpuUsageRatio1m
       poll_time_sec: 60
       tag: CPU
   # The total memory available in bytes for TMM (Traffic Management Module)
   - MIB: F5-BIGIP-SYSTEM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.44
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.44.0
       name: sysStatMemoryTotal
       poll_time_sec: 60
       tag: MemoryTotal
   # The memory in use in bytes for TMM (Traffic Management Module)
   - MIB: F5-BIGIP-SYSTEM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.45
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.45.0
       name: sysStatMemoryUsed
       poll_time_sec: 60
       tag: MemoryUsed
   # Chassis Serial Number
   - MIB: F5-BIGIP-SYSTEM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.3375.2.1.3.3.3
+      OID: 1.3.6.1.4.1.3375.2.1.3.3.3.0
       name: sysGeneralChassisSerialNum
       tag: chassis_serial_number
   # The number of bytes received by the system from server-side
   - MIB: F5-BIGIP-SYSTEM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.10
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.10.0
       name: sysStatServerBytesIn
       tag: server_side_bytes_in
   # The number of bytes sent to server-side from the system
   - MIB: F5-BIGIP-SYSTEM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.12
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.12.0
       name: sysStatServerBytesOut
       tag: server_side_bytes_out
   # The number of bytes received by the system from client-side
   - MIB: F5-BIGIP-SYSTEM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.3
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.3.0
       name: sysStatClientBytesIn
       tag: client_side_bytes_in
   # The number of bytes sent to client-side from the system
   - MIB: F5-BIGIP-SYSTEM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.5
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.5.0
       name: sysStatClientBytesOut
       tag: client_side_bytes_out
   # The total connections from client-side to the system
   - MIB: F5-BIGIP-SYSTEM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.7
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.7.0
       name: sysStatClientTotConns
       tag: client_side_total_connections
   # The current connections from client-side to the system
   - MIB: F5-BIGIP-SYSTEM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.8
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.8.0
       name: sysStatClientCurConns
       tag: client_side_current_connections
   # The current number of concurrent native connections with established SSL sessions being maintained by the filter
   - MIB: F5-BIGIP-SYSTEM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.3375.2.1.1.2.9.4
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.9.4.0
       name: sysClientsslStatCurNativeConns
       tag: current_native_connections
   # The current number of concurrent COMPAT connections with established SSL sessions being maintained by the filter
   - MIB: F5-BIGIP-SYSTEM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.3375.2.1.1.2.9.7
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.9.7.0
       name: sysClientsslStatCurCompatConns
       tag: current_compat_connections
 

--- a/profiles/kentik_snmp/fireeye/fireeye.yml
+++ b/profiles/kentik_snmp/fireeye/fireeye.yml
@@ -164,13 +164,12 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.25597.13.1.45.0
       name: feHoldQueueEmailCount
-      
   # Total analyzed object count
   - MIB: FE-FIREEYE-MIB
     symbol:
       OID: 1.3.6.1.4.1.25597.15.1.1.0
       name: feTotalObjectAnalyzedCount
-   # Total malicious object count
+  # Total malicious object count
   - MIB: FE-FIREEYE-MIB
     symbol:
       OID: 1.3.6.1.4.1.25597.15.1.4.0

--- a/profiles/kentik_snmp/hp/hp-icf-switch.yml
+++ b/profiles/kentik_snmp/hp/hp-icf-switch.yml
@@ -17,7 +17,7 @@ metrics:
   - MIB: STATISTICS-MIB
     symbol:
       name: hpSwitchCpuStat
-      OID: 1.3.6.1.4.1.11.2.14.11.5.1.9.6.1
+      OID: 1.3.6.1.4.1.11.2.14.11.5.1.9.6.1.0
       tag: CPU
   # A table that contains information on all the local memory for each slot
   - MIB: NETSWITCH-MIB

--- a/profiles/kentik_snmp/infoblox/infoblox-ipam.yml
+++ b/profiles/kentik_snmp/infoblox/infoblox-ipam.yml
@@ -147,12 +147,12 @@ metric_tags:
   # Infoblox One hardware type
   - column:
       name: ibHardwareType
-      OID: 1.3.6.1.4.1.7779.3.1.1.2.1.4
+      OID: 1.3.6.1.4.1.7779.3.1.1.2.1.4.0
   # Infoblox One device serial number
   - column:
       name: ibSerialNumber
-      OID: 1.3.6.1.4.1.7779.3.1.1.2.1.6
+      OID: 1.3.6.1.4.1.7779.3.1.1.2.1.6.0
   # Infoblox One NIOS version
   - column:
       name: ibNiosVersion
-      OID: 1.3.6.1.4.1.7779.3.1.1.2.1.7
+      OID: 1.3.6.1.4.1.7779.3.1.1.2.1.7.0

--- a/profiles/kentik_snmp/netapp/netapp-cluster.yml
+++ b/profiles/kentik_snmp/netapp/netapp-cluster.yml
@@ -46,7 +46,6 @@ metrics:
         alpha: 2
         mips: 3
         sparc: 4
-
   # Scalar CPU OIDs
   - MIB: NETAPP-MIB
     symbol:
@@ -57,7 +56,6 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.789.1.2.1.6.0
       name: cpuCount
-
   # Tabular CPU OIDs
   - MIB: NETAPP-MIB
     table:
@@ -75,7 +73,6 @@ metrics:
       - column:
           OID: 1.3.6.1.4.1.789.1.2.1.14.1.7
           name: cDOTCpuCount
-
   # Scalar Misc OIDs
   - MIB: NETAPP-MIB
     symbol:
@@ -96,18 +93,16 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.789.1.2.2.25.0
       name: miscGlobalStatusMessage
-
   # Scalar Clusterd Failover OIDs
   - MIB: NETAPP-MIB
     symbol:
-      OID: 1.3.6.1.4.1.789.1.2.3.8
+      OID: 1.3.6.1.4.1.789.1.2.3.8.0
       name: cfInterconnectStatus
       enum:
         notPresent: 1
         down: 2
         partialFailure: 3
         up: 4
-
   # Scalar Consistency Point OIDs
   - MIB: NETAPP-MIB
     symbol:
@@ -153,7 +148,6 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.789.1.2.6.13.0
       name: cpFromLowDatavecsOps
-
   # Scalar AutoSupport OIDs
   - MIB: NETAPP-MIB
     symbol:
@@ -177,25 +171,21 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.789.1.2.7.4.0
       name: autosupportFailedSends
-
   # Scalar df OIDs
   - MIB: NETAPP-MIB
     symbol:
       OID: 1.3.6.1.4.1.789.1.5.6.0
       name: dfNumber
-
   # Scalar vol OIDs
   - MIB: NETAPP-MIB
     symbol:
       OID: 1.3.6.1.4.1.789.1.5.9.0
       name: volNumber
-
   # Scalar aggr OIDs
   - MIB: NETAPP-MIB
     symbol:
       OID: 1.3.6.1.4.1.789.1.5.12.0
       name: aggrNumber
-
   # Scalar disk OIDs
   - MIB: NETAPP-MIB
     symbol:
@@ -241,55 +231,46 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.789.1.6.4.11.0
       name: diskPrefailedCount
-
   # Scalar RAIDV OIDs
   - MIB: NETAPP-MIB
     symbol:
       OID: 1.3.6.1.4.1.789.1.6.5.0
       name: raidVNumber
-
   # Scalar Spare OIDs
   - MIB: NETAPP-MIB
     symbol:
       OID: 1.3.6.1.4.1.789.1.6.6.0
       name: spareNumber
-
   # Scalar Other Disk OIDs
   - MIB: NETAPP-MIB
     symbol:
       OID: 1.3.6.1.4.1.789.1.6.7.0
       name: otherDiskNumber
-
   # Scalar RAIDP OIDs
   - MIB: NETAPP-MIB
     symbol:
       OID: 1.3.6.1.4.1.789.1.6.8.0
       name: raidPNumber
-
   # Scalar Out of Date OIDs
   - MIB: NETAPP-MIB
     symbol:
       OID: 1.3.6.1.4.1.789.1.6.12.0
       name: outOfDateDiskCount
-
   # Scalar Net Connection OIDs
   - MIB: NETAPP-MIB
     symbol:
-      OID: 1.3.6.1.4.1.789.1.8.3.6.36
+      OID: 1.3.6.1.4.1.789.1.8.3.6.36.0
       name: ncHttpActiveCliConns
-
   # Scalar encl OIDs
   - MIB: NETAPP-MIB
     symbol:
       OID: 1.3.6.1.4.1.789.1.21.1.1.0
       name: enclNumber
-
   # Scalar External Cache OIDs
   - MIB: NETAPP-MIB
     symbol:
-      OID: 1.3.6.1.4.1.789.1.26.8
+      OID: 1.3.6.1.4.1.789.1.26.8.0
       name: extcache64Hits
-
   # qvStateTable
   - MIB: NETAPP-MIB
     table:
@@ -314,7 +295,6 @@ metrics:
       - column: 
           OID: 1.3.6.1.4.1.789.1.4.4.1.5
           name: qvStateVserver
-
   # dfTable
   - MIB: NETAPP-MIB
     table:
@@ -399,7 +379,6 @@ metrics:
           enum:
             false: 0
             true: 1
-
   # volTable
   - MIB: NETAPP-MIB
     table:
@@ -439,7 +418,6 @@ metrics:
       - column: 
           OID: 1.3.6.1.4.1.789.1.5.8.1.9
           name: volAggrName
-
   # qtreeTable
   - MIB: NETAPP-MIB
     table:
@@ -479,7 +457,6 @@ metrics:
       - column: 
           OID: 1.3.6.1.4.1.789.1.5.10.1.5
           name: qtreeName
-
   # aggrTable
   - MIB: NETAPP-MIB
     table:
@@ -509,7 +486,6 @@ metrics:
       - column: 
           OID: 1.3.6.1.4.1.789.1.5.11.1.10
           name: aggrType
-
   # raidVTable
   - MIB: NETAPP-MIB
     table:
@@ -596,7 +572,6 @@ metrics:
       - column: 
           OID: 1.3.6.1.4.1.789.1.6.2.1.33
           name: raidVDiskCopyDestDiskName
-
   # spareTable
   - MIB: NETAPP-MIB
     table:
@@ -649,7 +624,6 @@ metrics:
       - column: 
           OID: 1.3.6.1.4.1.789.1.6.3.1.21
           name: spareDiskType
-
   # raidPTable
   - MIB: NETAPP-MIB
     table:
@@ -734,7 +708,6 @@ metrics:
       - column: 
           OID: 1.3.6.1.4.1.789.1.6.10.1.32
           name: raidPDiskCopyDestDiskName
-
   # plexTable
   - MIB: NETAPP-MIB
     table:
@@ -759,7 +732,6 @@ metrics:
       - column: 
           OID: 1.3.6.1.4.1.789.1.6.11.1.3
           name: plexVolName
-
   # snapvaultStatusTable
   - MIB: NETAPP-MIB
     table:
@@ -788,7 +760,6 @@ metrics:
         column:
           OID: 1.3.6.1.4.1.789.1.19.11.1.3
           name: svDst
-
   # snapmirrorStatusTable
   - MIB: NETAPP-MIB
     table:
@@ -806,7 +777,6 @@ metrics:
       - column:
           OID: 1.3.6.1.4.1.789.1.9.20.1.5
           name: snapmirrorState
-
   # enclTable
   - MIB: NETAPP-MIB
     table:
@@ -887,7 +857,6 @@ metrics:
       - column: 
           OID: 1.3.6.1.4.1.789.1.21.1.2.1.65
           name: enclNodeName
-          
   # haTable
   - MIB: NETAPP-MIB
     table:
@@ -948,7 +917,6 @@ metrics:
             down: 2
             partialFailure: 3
             up: 4
-
   # netifTable
   - MIB: NETAPP-MIB
     table:

--- a/profiles/kentik_snmp/nvidia/cumulus-linux-switch.yml
+++ b/profiles/kentik_snmp/nvidia/cumulus-linux-switch.yml
@@ -56,132 +56,132 @@ metrics:
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: l3HostTableCurrentEntries
-      OID: 1.3.6.1.4.1.40310.1.1.1
+      OID: 1.3.6.1.4.1.40310.1.1.1.0
   # The maximum possible entries in the L3 Host table. The Host table is defined as the table holding the ARP/ND cache.
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: l3HostTableMaxEntries
-      OID: 1.3.6.1.4.1.40310.1.1.2
+      OID: 1.3.6.1.4.1.40310.1.1.2.0
   # The number of L3 Routing table entries currently in use
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: l3RoutingTableCurrentEntries
-      OID: 1.3.6.1.4.1.40310.1.1.3
+      OID: 1.3.6.1.4.1.40310.1.1.3.0
   # The maximum possible entries in the L3 Routing table. L3 Routing table is defined as the table holding the longest prefix match (LPM) entries.
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: l3RoutingTableMaxEntries
-      OID: 1.3.6.1.4.1.40310.1.1.4
+      OID: 1.3.6.1.4.1.40310.1.1.4.0
   # The number of L3 Next Hop table entries currently in use
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: l3NextHopTableCurrentEntries
-      OID: 1.3.6.1.4.1.40310.1.1.5
+      OID: 1.3.6.1.4.1.40310.1.1.5.0
   # The maximum possible entries in the L3 Next Hop table. The L3 Next Hop table holds information about the next hop(s) associated with a routing table entry.
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: l3NextHopTableMaxEntries
-      OID: 1.3.6.1.4.1.40310.1.1.6
+      OID: 1.3.6.1.4.1.40310.1.1.6.0
   # The number of ECMP Next Hop table entries currently in use
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: l3EcmpNextHopTableCurrentEntries
-      OID: 1.3.6.1.4.1.40310.1.1.9
+      OID: 1.3.6.1.4.1.40310.1.1.9.0
   # The maximum possible entries in the ECMP Next Hop table. ECMP Next Hop table stores information about the next hop associated with a routing table entry that has multiple equal cost next hop neighbors.
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: l3EcmpNextHopTableMaxEntries
-      OID: 1.3.6.1.4.1.40310.1.1.10
+      OID: 1.3.6.1.4.1.40310.1.1.10.0
   # The current number of Ingress entries in the Network Access Control List table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: ingressAclCurrentEntries
-      OID: 1.3.6.1.4.1.40310.1.1.11
+      OID: 1.3.6.1.4.1.40310.1.1.11.0
   # The maximum possible Ingress entries in the Network Access Control table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: ingressAclMaxEntries
-      OID: 1.3.6.1.4.1.40310.1.1.12
+      OID: 1.3.6.1.4.1.40310.1.1.12.0
   # The current number of Ingress counters in the Network Access Control List table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: ingressAclCurrentCounters
-      OID: 1.3.6.1.4.1.40310.1.1.13
+      OID: 1.3.6.1.4.1.40310.1.1.13.0
   # The maximum possible Ingress counters in the Network Access Control table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: ingressAclMaxCounters
-      OID: 1.3.6.1.4.1.40310.1.1.14
+      OID: 1.3.6.1.4.1.40310.1.1.14.0
   # The current number of Ingress meters in the Network Access Control List table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: ingressAclCurrentMeters
-      OID: 1.3.6.1.4.1.40310.1.1.15
+      OID: 1.3.6.1.4.1.40310.1.1.15.0
   # The maximum possible Ingress meters in the Network Access Control table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: ingressAclMaxMeters
-      OID: 1.3.6.1.4.1.40310.1.1.16
+      OID: 1.3.6.1.4.1.40310.1.1.16.0
   # The current number of Ingress slices in the Network Access Control List table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: ingressAclCurrentSlices
-      OID: 1.3.6.1.4.1.40310.1.1.17
+      OID: 1.3.6.1.4.1.40310.1.1.17.0
   # The maximum possible Ingress slices in the Network Access Control table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: ingressAclMaxSlices
-      OID: 1.3.6.1.4.1.40310.1.1.18
+      OID: 1.3.6.1.4.1.40310.1.1.18.0
   # The current number of Egress entries in the Network Access Control List table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: egressAclCurrentEntries
-      OID: 1.3.6.1.4.1.40310.1.1.19
+      OID: 1.3.6.1.4.1.40310.1.1.19.0
   # The maximum possible Egress entries in the Network Access Control table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: egressAclMaxEntries
-      OID: 1.3.6.1.4.1.40310.1.1.20
+      OID: 1.3.6.1.4.1.40310.1.1.20.0
   # The current number of Egress counters in the Network Access Control List table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: egressAclCurrentCounters
-      OID: 1.3.6.1.4.1.40310.1.1.21
+      OID: 1.3.6.1.4.1.40310.1.1.21.0
   # The maximum possible Egress counters in the Network Access Control table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: egressAclMaxCounters
-      OID: 1.3.6.1.4.1.40310.1.1.22
+      OID: 1.3.6.1.4.1.40310.1.1.22.0
   # The current number of Egress meters in the Network Access Control List table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: egressAclCurrentMeters
-      OID: 1.3.6.1.4.1.40310.1.1.23
+      OID: 1.3.6.1.4.1.40310.1.1.23.0
   # The maximum possible Egress meters in the Network Access Control table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: egressAclMaxMeters
-      OID: 1.3.6.1.4.1.40310.1.1.24
+      OID: 1.3.6.1.4.1.40310.1.1.24.0
   # The current number of Egress slices in the Network Access Control List table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: egressAclCurrentSlices
-      OID: 1.3.6.1.4.1.40310.1.1.25
+      OID: 1.3.6.1.4.1.40310.1.1.25.0
   # The maximum possible Egress slices in the Network Access Control table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: egressAclMaxSlices
-      OID: 1.3.6.1.4.1.40310.1.1.26
+      OID: 1.3.6.1.4.1.40310.1.1.26.0
 # The number of L2 Mac table entries currently in use
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: l2MacTableCurrentEntries
-      OID: 1.3.6.1.4.1.40310.1.2.1
+      OID: 1.3.6.1.4.1.40310.1.2.1.0
   # The maximum possible entries in the L2 Mac table
   - MIB: CUMULUS-RESOURCE-QUERY-MIB
     symbol:
       name: l2MacTableMaxEntries
-      OID: 1.3.6.1.4.1.40310.1.2.2
+      OID: 1.3.6.1.4.1.40310.1.2.2.0
   # This table breaks out ingress packet discards into more reason-specific discard counters with 64 bits.
   - MIB: CUMULUS-COUNTERS-MIB
     table:

--- a/profiles/kentik_snmp/pulse_secure/pulse-secure.yml
+++ b/profiles/kentik_snmp/pulse_secure/pulse-secure.yml
@@ -16,107 +16,107 @@ sysobjectid: 1.3.6.1.4.1.12532.256.*
 metrics:
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.1
+      OID: 1.3.6.1.4.1.12532.1.0
       name: logFullPercent
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.2
+      OID: 1.3.6.1.4.1.12532.2.0
       name: signedInWebUsers
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.3
+      OID: 1.3.6.1.4.1.12532.3.0
       name: signedInMailUsers
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.10
+      OID: 1.3.6.1.4.1.12532.10.0
       name: iveCpuUtil
       poll_time_sec: 60
       tag: CPU
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.11
+      OID: 1.3.6.1.4.1.12532.11.0
       name: iveMemoryUtil
       poll_time_sec: 60
       tag: MemoryUtilization
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.12
+      OID: 1.3.6.1.4.1.12532.12.0
       name: iveConcurrentUsers
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.13
+      OID: 1.3.6.1.4.1.12532.13.0
       name: clusterConcurrentUsers
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.14
+      OID: 1.3.6.1.4.1.12532.14.0
       name: iveTotalHits
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.15
+      OID: 1.3.6.1.4.1.12532.15.0
       name: iveFileHits
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.16
+      OID: 1.3.6.1.4.1.12532.16.0
       name: iveWebHits
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.17
+      OID: 1.3.6.1.4.1.12532.17.0
       name: iveAppletHits
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.18
+      OID: 1.3.6.1.4.1.12532.18.0
       name: ivetermHits
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.19
+      OID: 1.3.6.1.4.1.12532.19.0
       name: iveSAMHits
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.20
+      OID: 1.3.6.1.4.1.12532.20.0
       name: iveNCHits
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.21
+      OID: 1.3.6.1.4.1.12532.21.0
       name: meetingHits
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.24
+      OID: 1.3.6.1.4.1.12532.24.0
       name: iveSwapUtil
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.25
+      OID: 1.3.6.1.4.1.12532.25.0
       name: diskFullPercent
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.42
+      OID: 1.3.6.1.4.1.12532.42.0
       name: iveTemperature
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.43
+      OID: 1.3.6.1.4.1.12532.43.0
       name: iveVPNTunnels
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.44
+      OID: 1.3.6.1.4.1.12532.44.0
       name: iveSSLConnections
   - MIB: JUNIPER-IVE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.12532.48
+      OID: 1.3.6.1.4.1.12532.48.0
       name: iveTotalSignedInUsers
 
 metric_tags:
   - column:
-      OID: 1.3.6.1.4.1.12532.6
+      OID: 1.3.6.1.4.1.12532.6.0
       name: productName
     tag: productName
   - column:
-      OID: 1.3.6.1.4.1.12532.7
+      OID: 1.3.6.1.4.1.12532.7.0
       name: productVersion
     tag: product_version
   - column:
-      OID: 1.3.6.1.4.1.12532.45
+      OID: 1.3.6.1.4.1.12532.45.0
       name: esapVersion
     tag: product_name
   - column:
-      OID: 1.3.6.1.4.1.12532.55
+      OID: 1.3.6.1.4.1.12532.55.0
       name: iveMaxConcurrentUsersLicenseCapacity
     tag: licensed_capacity


### PR DESCRIPTION
adding back scalar OID indexes (trailing `.0`) to remediate some missed metric queries.