### PR TITLE
feat: adding opnsense profile

### DIFF
--- a/profiles/kentik_snmp/_general/net-snmp.yml
+++ b/profiles/kentik_snmp/_general/net-snmp.yml
@@ -20,6 +20,7 @@ matches:
   "^pfsense": pf_sense.yml
   "barracuda email security gateway": barracuda-email-gateway.yml
   "^uap-ac-inwall": unifi-access-point.yml
+  #"": opnsense-protectli.yml    # Needs to be updated to match on OPNsense devices using freeBSD sysOID
 
 sysobjectid:
   - 1.3.6.1.4.1.8072.*

--- a/profiles/kentik_snmp/_general/net-snmp.yml
+++ b/profiles/kentik_snmp/_general/net-snmp.yml
@@ -20,7 +20,7 @@ matches:
   "^pfsense": pf_sense.yml
   "barracuda email security gateway": barracuda-email-gateway.yml
   "^uap-ac-inwall": unifi-access-point.yml
-  #"": opnsense-protectli.yml    # Needs to be updated to match on OPNsense devices using freeBSD sysOID
+  "root@sensey": opnsense-protectli.yml
 
 sysobjectid:
   - 1.3.6.1.4.1.8072.*

--- a/profiles/kentik_snmp/opnsense/opnsense-protectli.yml
+++ b/profiles/kentik_snmp/opnsense/opnsense-protectli.yml
@@ -1,0 +1,36 @@
+# Based on SNMP walk from Protectli VP2410
+# CPU metrics are not found on this device
+---
+extends:
+  - if-mib.yml
+  - ip-mib.yml
+  - system-mib.yml
+
+provider: kentik-router
+
+sysobjectid:
+  - 1.3.6.1.4.1.8072.3.2.8.opnsense
+
+metrics:
+  # Memory Utilization - polled at 60s to support anomaly detection
+  # Memory Total
+  - MIB: HOST-RESOURCES-MIB
+    symbol:
+      OID: 1.3.6.1.2.1.25.2.3.1.6.1
+      name: hrStorageUsed
+      tag: MemoryTotal
+      poll_time_sec: 60
+  # Memory Buffers
+  - MIB: HOST-RESOURCES-MIB
+    symbol:
+      name: hrStorageUsed
+      OID: 1.3.6.1.2.1.25.2.3.1.6.6
+      tag: MemoryBuffer
+      poll_time_sec: 60
+  # Memory Cache
+  - MIB: HOST-RESOURCES-MIB
+    symbol:
+      name: hrStorageUsed
+      OID: 1.3.6.1.2.1.25.2.3.1.6.7
+      tag: MemoryCache
+      poll_time_sec: 60


### PR DESCRIPTION
resolves #121 

-- pending confirmation of `sysDescr` so we can build a match as these devices use the generic freeBSD system object identifier