### PR TITLE
Revert "Remove CPU and Mem in favor of common Cisco OIDs"

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-nexus.yml
+++ b/profiles/kentik_snmp/cisco/cisco-nexus.yml
@@ -80,3 +80,16 @@ sysobjectid:
   - 1.3.6.1.4.1.9.12.3.1.3.2039    # NEXUS 3548P-XL
   - 1.3.6.1.4.1.9.12.3.1.9.85.8    # NEXUS 3172
 
+metrics:
+  - MIB: CISCO-SYSTEM-EXT-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.9.9.305.1.1.1.0
+      name: cseSysCPUUtilization
+      poll_time_sec: 60
+      tag: CPU
+  - MIB: CISCO-SYSTEM-EXT-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.9.9.305.1.1.2.0
+      name: cseSysMemoryUtilization
+      poll_time_sec: 60
+      tag: MemoryUtilization


### PR DESCRIPTION
Reverts kentik/snmp-profiles#128

pulling this back to restore nexus-specific OIDs for CPU/Mem