### PR TITLE
fix/netapp enum options

### DIFF
--- a/profiles/kentik_snmp/netapp/netapp-cluster.yml
+++ b/profiles/kentik_snmp/netapp/netapp-cluster.yml
@@ -1194,3 +1194,27 @@ metrics:
       - column: 
           OID: 1.3.6.1.4.1.789.1.22.1.2.1.2
           name: netifDesc
+  # Table of per-node statuses.
+  - MIB: NETAPP-MIB
+    table:
+      OID: 1.3.6.1.4.1.789.1.2.2.36
+      name: cDOTMiscTable
+    symbols:
+      # This indicates the overall status of the node.
+      - OID: 1.3.6.1.4.1.789.1.2.2.36.1.2
+        name: cDOTMiscGlobalStatus
+        enum:
+          other: 1
+          unknown: 2
+          ok: 3
+          nonCritical: 4
+          critical: 5
+          nonRecoverable: 6
+      # A string describing the global status, including a description of the condition (if any) that caused the status to be anything other than ok(3).
+      - OID: 1.3.6.1.4.1.789.1.2.2.36.1.3
+        name: cDOTMiscGlobalStatusMessage
+    metric_tags:
+      # Node name
+      - column: 
+          OID: 1.3.6.1.4.1.789.1.2.2.36.1.1
+          name: cDOTNodeName

--- a/profiles/kentik_snmp/netapp/netapp-cluster.yml
+++ b/profiles/kentik_snmp/netapp/netapp-cluster.yml
@@ -385,6 +385,7 @@ metrics:
       - OID: 1.3.6.1.4.1.789.1.5.4.1.20
         name: dfStatus
         enum:
+          unsupported: 0
           unmounted: 1
           mounted: 2
           frozen: 3
@@ -399,6 +400,7 @@ metrics:
       - OID: 1.3.6.1.4.1.789.1.5.4.1.21
         name: dfMirrorStatus
         enum:
+          unsupported: 0
           invalid: 1
           uninitialized: 2
           needcpcheck: 3


### PR DESCRIPTION
 * adding fix to handle `dfTable` entries returning `0` for `dfStatus` and `dfMirrorStatus` metrics in enumeration
 * adding new `cDOTMiscTable` based on customer request for `cDOTMiscGlobalStatus` and `cDOTMiscGlobalStatusMessage` for their nodes. This was created from an SNMP walk and the notes found in [this NetApp documentation](https://www.netapp.com/media/16417-tr-4220.pdf) (page 45) as I couldn't find any reference to this new(ish) table on public sources for the `NETAPP-MIB`

example from SNMP walk results: 

```
.1.3.6.1.4.1.789.1.2.2.36.1.1.108.99.121.50.45.102.105.108.101.114.48.49.97 = STRING: "**-filer01a"
.1.3.6.1.4.1.789.1.2.2.36.1.1.108.99.121.50.45.102.105.108.101.114.48.49.98 = STRING: "**-filer01b"
.1.3.6.1.4.1.789.1.2.2.36.1.1.108.99.121.50.45.102.105.108.101.114.48.49.99 = STRING: "**-filer01c"
.1.3.6.1.4.1.789.1.2.2.36.1.1.108.99.121.50.45.102.105.108.101.114.48.49.100 = STRING: "**-filer01d"
.1.3.6.1.4.1.789.1.2.2.36.1.2.108.99.121.50.45.102.105.108.101.114.48.49.97 = INTEGER: 3
.1.3.6.1.4.1.789.1.2.2.36.1.2.108.99.121.50.45.102.105.108.101.114.48.49.98 = INTEGER: 3
.1.3.6.1.4.1.789.1.2.2.36.1.2.108.99.121.50.45.102.105.108.101.114.48.49.99 = INTEGER: 3
.1.3.6.1.4.1.789.1.2.2.36.1.2.108.99.121.50.45.102.105.108.101.114.48.49.100 = INTEGER: 3
.1.3.6.1.4.1.789.1.2.2.36.1.3.108.99.121.50.45.102.105.108.101.114.48.49.97 = STRING: "The system's global status is normal. "
.1.3.6.1.4.1.789.1.2.2.36.1.3.108.99.121.50.45.102.105.108.101.114.48.49.98 = STRING: "The system's global status is normal. "
.1.3.6.1.4.1.789.1.2.2.36.1.3.108.99.121.50.45.102.105.108.101.114.48.49.99 = STRING: "The system's global status is normal. "
.1.3.6.1.4.1.789.1.2.2.36.1.3.108.99.121.50.45.102.105.108.101.114.48.49.100 = STRING: "The system's global status is normal. "
```