### PR TITLE
feat: adding netgear m4300-52g switch profile

### DIFF
--- a/profiles/kentik_snmp/_template.yml
+++ b/profiles/kentik_snmp/_template.yml
@@ -74,5 +74,10 @@ metrics:
     #   <current> == LittleEndian | BigEndian
     #   <desired> == uint16 | uint32 | uint64
     # hextoip == converts a hex string into a 4 octet ip addresses string
+    # regexp == places a regex match on the OID output to capture substrings
+    #    Example OID result: "    5 Secs ( 96.3762%)   60 Secs ( 62.8549%)  300 Secs ( 25.2877%)"
+    #    Example Conversion:
+    #      conversion: "regexp:60 Secs.*?(\\d+)"
+    #    Results: 62
     
 #OPTIONAL: You can also create an additional 'metric_tags' section here to provide OID's to decorate all the scalar OIDs in this profile.  Note that tags applied at this level do no get decorated to data inside of table stanzas.

--- a/profiles/kentik_snmp/_template.yml
+++ b/profiles/kentik_snmp/_template.yml
@@ -74,7 +74,7 @@ metrics:
     #   <current> == LittleEndian | BigEndian
     #   <desired> == uint16 | uint32 | uint64
     # hextoip == converts a hex string into a 4 octet ip addresses string
-    # regexp == places a regex match on the OID output to capture substrings
+    # regexp == places a regex match on the OID output to capture substrings; needs to be wrapped in quotes and have backslashes escaped
     #    Example OID result: "    5 Secs ( 96.3762%)   60 Secs ( 62.8549%)  300 Secs ( 25.2877%)"
     #    Example Conversion:
     #      conversion: "regexp:60 Secs.*?(\\d+)"

--- a/profiles/kentik_snmp/netgear/netgear-switch.yml
+++ b/profiles/kentik_snmp/netgear/netgear-switch.yml
@@ -1,0 +1,45 @@
+# https://github.com/librenms/librenms/blob/master/mibs/netgear/NETGEAR-SWITCHING-MIB
+---
+
+extends:
+  - system-mib.yml
+  - if-mib.yml
+
+sysobjectid: 
+  - 1.3.6.1.4.1.4526.100.1.31    # M4300-52G ProSAFE 48-port
+
+provider: kentik-switch
+
+metrics:
+  # The total memory free for utilization in KBytes.
+  - MIB: NETGEAR-SWITCHING-MIB
+    symbol:
+      name: agentSwitchCpuProcessMemFree
+      OID: 1.3.6.1.4.1.4526.10.1.1.4.1.0
+      poll_time_sec: 60
+      tag: MemoryFree
+  # The total memory available in KBytes.
+  - MIB: NETGEAR-SWITCHING-MIB
+    symbol:
+      name: agentSwitchCpuProcessMemAvailable
+      OID: 1.3.6.1.4.1.4526.10.1.1.4.2.0
+      poll_time_sec: 60
+      tag: MemoryTotal
+  # Total CPU utilization over a period of 5, 60, 300 seconds.
+  - MIB: NETGEAR-SWITCHING-MIB
+    symbol:
+      name: agentSwitchCpuProcessTotalUtilization
+      OID: 1.3.6.1.4.1.4526.10.1.1.4.9.0
+      poll_time_sec: 60
+      tag: CPU
+      conversion:
+        regexp: ".*60 Secs \( (\d+\.\d+).*"
+metric_tags:
+  # The switch's Machine Model.
+  - column:
+      name: agentInventoryMachineModel
+      OID: 1.3.6.1.4.1.4526.10.1.1.1.3.0
+  # Lists the version of software loaded on this unit.
+  - column:
+      name: agentInventorySoftwareVersion
+      OID: 1.3.6.1.4.1.4526.10.1.1.1.13.0

--- a/profiles/kentik_snmp/netgear/netgear-switch.yml
+++ b/profiles/kentik_snmp/netgear/netgear-switch.yml
@@ -32,8 +32,7 @@ metrics:
       OID: 1.3.6.1.4.1.4526.10.1.1.4.9.0
       poll_time_sec: 60
       tag: CPU
-      conversion:
-        regexp: ".*60 Secs \( (\d+\.\d+).*"
+      conversion: "regexp:60 Secs.*?(\\d+)"
 metric_tags:
   # The switch's Machine Model.
   - column:


### PR DESCRIPTION
resolves #148 

pending confirmation from @i3149 re: the `conversion` pattern used here for the CPU metric.

sample from walk: 

```
1.3.6.1.4.1.4526.10.1.1.4.9.0 = STRING: "    5 Secs ( 79.941%)   60 Secs ( 78.1594%)  300 Secs ( 66.1988%)"
```