### PR TITLE
chore: remove pan-entity-ext-mib

### DIFF
--- a/profiles/kentik_snmp/palo_alto/palo-alto.yml
+++ b/profiles/kentik_snmp/palo_alto/palo-alto.yml
@@ -8,6 +8,7 @@ extends:
   - tcp-mib.yml
   - udp-mib.yml
   - ip-mib.yml
+  - entity-sensor-mib.yml
 
 provider: kentik-firewall
 
@@ -58,41 +59,3 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.25461.2.1.2.5.1.3.0
       name: panGPGWUtilizationActiveTunnels
-  - MIB: PAN-ENTITY-EXT-MIB
-    symbol:
-      OID: 1.3.6.1.4.1.25461.1.1.7.1.1.2.0
-      name: panEntityTotalPowerUsed
-  - MIB: PAN-ENTITY-EXT-MIB
-    symbol:
-      OID: 1.3.6.1.4.1.25461.1.1.7.1.1.1.0
-      name: panEntityTotalPowerAvail
-  - MIB: PAN-ENTITY-EXT-MIB
-    table:
-      OID: 1.3.6.1.4.1.25461.1.1.7.1.2.1
-      name: panEntityFRUModuleTable
-    symbols:
-      - OID: 1.3.6.1.4.1.25461.1.1.7.1.2.1.1.1
-        name: panEntryFRUModulePowerUsed
-      - OID: 1.3.6.1.4.1.25461.1.1.7.1.2.1.1.2
-        name: panEntryFRUModuleNumPorts
-    metric_tags:
-      - MIB: ENTITY-MIB
-        column:
-          OID: 1.3.6.1.2.1.47.1.1.1.1.2
-          name: entPhysicalDescr
-        table: entPhysicalTable
-        tag: entity_description
-  - MIB: PAN-ENTITY-EXT-MIB
-    table:
-      OID: 1.3.6.1.4.1.25461.1.1.7.1.3.1
-      name: panEntityFanTrayTable
-    symbols:
-      - OID: 1.3.6.1.4.1.25461.1.1.7.1.3.1.1.1
-        name: panEntryFanTrayPowerUsed
-    metric_tags:
-      - MIB: ENTITY-MIB
-        column:
-          OID: 1.3.6.1.2.1.47.1.1.1.1.2
-          name: entPhysicalDescr
-        table: entPhysicalTable
-        tag: entity_description


### PR DESCRIPTION
Upon further research this table only shows the power consumption of the various hardware components which we don't need.  Entity status is picked up from the common entity sensor mib