### PR TITLE
fix: add processor description

### DIFF
--- a/profiles/kentik_snmp/_general/host-resources-mib.yml
+++ b/profiles/kentik_snmp/_general/host-resources-mib.yml
@@ -48,7 +48,7 @@ metrics:
       - OID: 1.3.6.1.2.1.25.3.3.1.2
         name: hrProcessorLoad
     metric_tags:
-      - tag: processor_id
-        column:
-          OID: 1.3.6.1.2.1.25.3.3.1.1
-          name: hrProcessorFrwID
+      - column:
+          OID: 1.3.6.1.2.1.25.3.2.1.3
+          name: hrDeviceDescr
+        tag: processor_description


### PR DESCRIPTION
To assist with identifying processors for devices that use hr mib, such as palo alto's