### PR TITLE
feat: add general lldp profile

### DIFF
--- a/profiles/kentik_snmp/_general/lldp-mib.yml
+++ b/profiles/kentik_snmp/_general/lldp-mib.yml
@@ -1,0 +1,39 @@
+# Profile is intended to be used in an extends block
+# http://oid-info.com/get/1.0.8802.1.1.2.1.4.1
+metrics:
+- MIB: LLDP-MIB
+  table:
+    OID: 1.0.8802.1.1.2.1.4.1
+    name: lldpRemTable
+  symbols:
+  - OID: 1.0.8802.1.1.2.1.4.1.1.1
+    name: lldpRemTimeMark
+    poll_time_sec: 300
+  - OID: 1.0.8802.1.1.2.1.4.1.1.2
+    name: lldpRemLocalPortNum
+    poll_time_sec: 300
+  - OID: 1.0.8802.1.1.2.1.4.1.1.3
+    name: lldpRemIndex
+    poll_time_sec: 300
+  - OID: 1.0.8802.1.1.2.1.4.1.1.4
+    name: lldpRemChassisIdSubtype
+    poll_time_sec: 300
+  - OID: 1.0.8802.1.1.2.1.4.1.1.5
+    name: lldpRemChassisId
+    poll_time_sec: 300
+  - OID: 1.0.8802.1.1.2.1.4.1.1.6
+    name: lldpRemPortIdSubtype
+    poll_time_sec: 300
+  - OID: 1.0.8802.1.1.2.1.4.1.1.7
+    name: lldpRemPortId
+    poll_time_sec: 300
+  - OID: 1.0.8802.1.1.2.1.4.1.1.8
+    name: lldpRemPortDesc
+    poll_time_sec: 300
+  - OID: 1.0.8802.1.1.2.1.4.1.1.9
+    name: lldpRemSysName
+    poll_time_sec: 300
+  - OID: 1.0.8802.1.1.2.1.4.1.1.10
+    name: lldpRemSysDesc
+    poll_time_sec: 300
+  metric_tags:

--- a/profiles/kentik_snmp/_general/lldp-mib.yml
+++ b/profiles/kentik_snmp/_general/lldp-mib.yml
@@ -1,27 +1,34 @@
 # Profile is intended to be used in an extends block
 # http://oid-info.com/get/1.0.8802.1.1.2.1.4.1
 metrics:
+  # This table contains one or more rows per physical network connection known to this agent.
   - MIB: LLDP-MIB
     table:
       OID: 1.0.8802.1.1.2.1.4.1
       name: lldpRemTable
     symbols:
+      # The type of encoding used to identify the chassis associated with the remote system.
       - OID: 1.0.8802.1.1.2.1.4.1.1.4
         name: lldpRemChassisIdSubtype
         poll_time_sec: 600
+        # The type of port identifier encoding used in the associated 'lldpRemPortId' object.
       - OID: 1.0.8802.1.1.2.1.4.1.1.6
         name: lldpRemPortIdSubtype
         poll_time_sec: 600
     metric_tags:
+      # The string value used to identify the port component associated with the remote system.
       - column:
           OID: 1.0.8802.1.1.2.1.4.1.1.7
           name: lldpRemPortId
+      # The string value used to identify the description of the given port associated with the remote system.
       - column:
           OID: 1.0.8802.1.1.2.1.4.1.1.8
           name: lldpRemPortDesc
+      # The string value used to identify the system name of the remote system.
       - column:
           OID: 1.0.8802.1.1.2.1.4.1.1.9
           name: lldpRemSysName
+      # The string value used to identify the system description of the remote system.
       - column:
           OID: 1.0.8802.1.1.2.1.4.1.1.10
           name: lldpRemSysDesc

--- a/profiles/kentik_snmp/_general/lldp-mib.yml
+++ b/profiles/kentik_snmp/_general/lldp-mib.yml
@@ -20,15 +20,7 @@ metrics:
       - column:
           OID: 1.0.8802.1.1.2.1.4.1.1.7
           name: lldpRemPortId
-      # The string value used to identify the description of the given port associated with the remote system.
-      - column:
-          OID: 1.0.8802.1.1.2.1.4.1.1.8
-          name: lldpRemPortDesc
       # The string value used to identify the system name of the remote system.
       - column:
           OID: 1.0.8802.1.1.2.1.4.1.1.9
           name: lldpRemSysName
-      # The string value used to identify the system description of the remote system.
-      - column:
-          OID: 1.0.8802.1.1.2.1.4.1.1.10
-          name: lldpRemSysDesc

--- a/profiles/kentik_snmp/_general/lldp-mib.yml
+++ b/profiles/kentik_snmp/_general/lldp-mib.yml
@@ -1,39 +1,27 @@
 # Profile is intended to be used in an extends block
 # http://oid-info.com/get/1.0.8802.1.1.2.1.4.1
 metrics:
-- MIB: LLDP-MIB
-  table:
-    OID: 1.0.8802.1.1.2.1.4.1
-    name: lldpRemTable
-  symbols:
-  - OID: 1.0.8802.1.1.2.1.4.1.1.1
-    name: lldpRemTimeMark
-    poll_time_sec: 300
-  - OID: 1.0.8802.1.1.2.1.4.1.1.2
-    name: lldpRemLocalPortNum
-    poll_time_sec: 300
-  - OID: 1.0.8802.1.1.2.1.4.1.1.3
-    name: lldpRemIndex
-    poll_time_sec: 300
-  - OID: 1.0.8802.1.1.2.1.4.1.1.4
-    name: lldpRemChassisIdSubtype
-    poll_time_sec: 300
-  - OID: 1.0.8802.1.1.2.1.4.1.1.5
-    name: lldpRemChassisId
-    poll_time_sec: 300
-  - OID: 1.0.8802.1.1.2.1.4.1.1.6
-    name: lldpRemPortIdSubtype
-    poll_time_sec: 300
-  - OID: 1.0.8802.1.1.2.1.4.1.1.7
-    name: lldpRemPortId
-    poll_time_sec: 300
-  - OID: 1.0.8802.1.1.2.1.4.1.1.8
-    name: lldpRemPortDesc
-    poll_time_sec: 300
-  - OID: 1.0.8802.1.1.2.1.4.1.1.9
-    name: lldpRemSysName
-    poll_time_sec: 300
-  - OID: 1.0.8802.1.1.2.1.4.1.1.10
-    name: lldpRemSysDesc
-    poll_time_sec: 300
-  metric_tags:
+  - MIB: LLDP-MIB
+    table:
+      OID: 1.0.8802.1.1.2.1.4.1
+      name: lldpRemTable
+    symbols:
+      - OID: 1.0.8802.1.1.2.1.4.1.1.4
+        name: lldpRemChassisIdSubtype
+        poll_time_sec: 600
+      - OID: 1.0.8802.1.1.2.1.4.1.1.6
+        name: lldpRemPortIdSubtype
+        poll_time_sec: 600
+    metric_tags:
+      - column:
+          OID: 1.0.8802.1.1.2.1.4.1.1.7
+          name: lldpRemPortId
+      - column:
+          OID: 1.0.8802.1.1.2.1.4.1.1.8
+          name: lldpRemPortDesc
+      - column:
+          OID: 1.0.8802.1.1.2.1.4.1.1.9
+          name: lldpRemSysName
+      - column:
+          OID: 1.0.8802.1.1.2.1.4.1.1.10
+          name: lldpRemSysDesc

--- a/profiles/kentik_snmp/arista/arista-switch.yml
+++ b/profiles/kentik_snmp/arista/arista-switch.yml
@@ -15,6 +15,7 @@ extends:
   - bgp4-mib.yml
   - tcp-mib.yml
   - udp-mib.yml
+  - lldp-mib.yml
 
 sysobjectid: 1.3.6.1.4.1.30065.*
 

--- a/profiles/kentik_snmp/cisco/cisco-all-devices.yml
+++ b/profiles/kentik_snmp/cisco/cisco-all-devices.yml
@@ -4,7 +4,6 @@
 # http://oid-info.com/get/1.3.6.1.4.1.9.9.500.1.2
 # http://oid-info.com/get/1.3.6.1.2.1.47.1.1.1.1.7
 # http://oid-info.com/get/1.3.6.1.4.1.9.9.388.1.2.2
-# http://oid-info.com/get/1.3.6.1.4.1.9.9.23.1.2.1
 ---
 
 extends:
@@ -714,29 +713,29 @@ metrics:
         tag: rtt_operation_admin_status
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.2
-          name: rttMonEchoAdminTargetAddress
+          name: rttMonEchoAdminTargetAddress 
           conversion: hextoip
         tag: rtt_echo_target_ip
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.5
-          name: rttMonEchoAdminTargetPort
+          name: rttMonEchoAdminTargetPort 
         tag: rtt_echo_target_port
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.6
-          name: rttMonEchoAdminSourceAddress
+          name: rttMonEchoAdminSourceAddress 
         tag: rtt_echo_source_address
         conversion: hextoip
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.7
-          name: rttMonEchoAdminSourcePort
+          name: rttMonEchoAdminSourcePort 
         tag: rtt_echo_source_port
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.12
-          name: rttMonEchoAdminNameServer
+          name: rttMonEchoAdminNameServer 
         tag: rtt_echo_name_server
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.15
-          name: rttMonEchoAdminURL
+          name: rttMonEchoAdminURL 
         tag: rtt_echo_url
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.9.1.6
@@ -807,66 +806,3 @@ metrics:
             statsRetrieveFormatError: 37
             statsRetrievePortInUse: 38
         tag: rtt_operation_sense
-  - MIB: CISCO-CDP-MIB
-    table:
-      OID: 1.3.6.1.4.1.9.9.23.1.2.1
-      name: cdpCacheTable
-    symbols:
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.1
-        name: cdpCacheIfIndex
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.2
-        name: cdpCacheDeviceIndex
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.3
-        name: cdpCacheAddressType
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.4
-        name: cdpCacheAddress
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.5
-        name: cdpCacheVersion
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.6
-        name: cdpCacheDeviceId
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.7
-        name: cdpCacheDevicePort
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.8
-        name: cdpCachePlatform
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.9
-        name: cdpCacheCapabilities
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.10
-        name: cdpCacheVTPMgmtDomain
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.11
-        name: cdpCacheNativeVLAN
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.12
-        name: cdpCacheDuplex
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.13
-        name: cdpCacheApplianceID
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.17
-        name: cdpCacheSysName
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.18
-        name: cdpCacheSysObjectID
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.19
-        name: cdpCachePrimaryMgmtAddrType
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.20
-        name: cdpCachePrimaryMgmtAddr
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.23
-        name: cdpCachePhysLocation
-        poll_time_sec: 600
-      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.24
-        name: cdpCacheLastChange
-        poll_time_sec: 600
-    metric_tags:

--- a/profiles/kentik_snmp/cisco/cisco-all-devices.yml
+++ b/profiles/kentik_snmp/cisco/cisco-all-devices.yml
@@ -4,6 +4,7 @@
 # http://oid-info.com/get/1.3.6.1.4.1.9.9.500.1.2
 # http://oid-info.com/get/1.3.6.1.2.1.47.1.1.1.1.7
 # http://oid-info.com/get/1.3.6.1.4.1.9.9.388.1.2.2
+# http://oid-info.com/get/1.3.6.1.4.1.9.9.23.1.2.1
 ---
 
 extends:
@@ -713,29 +714,29 @@ metrics:
         tag: rtt_operation_admin_status
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.2
-          name: rttMonEchoAdminTargetAddress 
+          name: rttMonEchoAdminTargetAddress
           conversion: hextoip
         tag: rtt_echo_target_ip
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.5
-          name: rttMonEchoAdminTargetPort 
+          name: rttMonEchoAdminTargetPort
         tag: rtt_echo_target_port
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.6
-          name: rttMonEchoAdminSourceAddress 
+          name: rttMonEchoAdminSourceAddress
         tag: rtt_echo_source_address
         conversion: hextoip
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.7
-          name: rttMonEchoAdminSourcePort 
+          name: rttMonEchoAdminSourcePort
         tag: rtt_echo_source_port
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.12
-          name: rttMonEchoAdminNameServer 
+          name: rttMonEchoAdminNameServer
         tag: rtt_echo_name_server
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.2.1.15
-          name: rttMonEchoAdminURL 
+          name: rttMonEchoAdminURL
         tag: rtt_echo_url
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.9.1.6
@@ -806,3 +807,66 @@ metrics:
             statsRetrieveFormatError: 37
             statsRetrievePortInUse: 38
         tag: rtt_operation_sense
+  - MIB: CISCO-CDP-MIB
+    table:
+      OID: 1.3.6.1.4.1.9.9.23.1.2.1
+      name: cdpCacheTable
+    symbols:
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.1
+        name: cdpCacheIfIndex
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.2
+        name: cdpCacheDeviceIndex
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.3
+        name: cdpCacheAddressType
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.4
+        name: cdpCacheAddress
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.5
+        name: cdpCacheVersion
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.6
+        name: cdpCacheDeviceId
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.7
+        name: cdpCacheDevicePort
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.8
+        name: cdpCachePlatform
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.9
+        name: cdpCacheCapabilities
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.10
+        name: cdpCacheVTPMgmtDomain
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.11
+        name: cdpCacheNativeVLAN
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.12
+        name: cdpCacheDuplex
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.13
+        name: cdpCacheApplianceID
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.17
+        name: cdpCacheSysName
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.18
+        name: cdpCacheSysObjectID
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.19
+        name: cdpCachePrimaryMgmtAddrType
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.20
+        name: cdpCachePrimaryMgmtAddr
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.23
+        name: cdpCachePhysLocation
+        poll_time_sec: 600
+      - OID: 1.3.6.1.4.1.9.9.23.1.2.1.1.24
+        name: cdpCacheLastChange
+        poll_time_sec: 600
+    metric_tags:


### PR DESCRIPTION
Adding an initial profile to collect LLDP data. Only added it to `arista-switch` so far, as that's the only place I've been able to test. Open to feedback on if I should change anything that's here.

Note: I've set the poll time to 10 minutes. The real data we want is encapsulated within `metric_tags`, and until we have a way to poll those more frequently it's not worth collecting this data too often (however, still want often enough to adequately test the relationship synthesis pipeline).

Link to see sample of data in NR1: https://staging.onenr.io/0znQx83VJQV