### PR TITLE
chore: remove nexus specific cpu tag

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-nexus.yml
+++ b/profiles/kentik_snmp/cisco/cisco-nexus.yml
@@ -86,7 +86,6 @@ metrics:
       OID: 1.3.6.1.4.1.9.9.305.1.1.1.0
       name: cseSysCPUUtilization
       poll_time_sec: 60
-      tag: CPU
   - MIB: CISCO-SYSTEM-EXT-MIB
     symbol:
       OID: 1.3.6.1.4.1.9.9.305.1.1.2.0


### PR DESCRIPTION
Received complaints that our Nexus profile reports significantly higher CPU than other monitoring tools.  

This OID, 1.3.6.1.4.1.9.9.305.1.1.1.0, is widely considered to be too erratic to monitor with because it does not do the time averaging that more typical load OID's do.  Removing the tag so we can collect it alongside the common Cisco CPU OID.
Confirmed from a dozen Nexus walks that the Cisco generic CPU OID, 1.3.6.1.4.1.9.9.109.1.1.1.1.7, is available for all of them.

Once we have both numbers side by side we can assess how they behave differently and a final call if we need to collect both or one or whatever.