### PR TITLE
chore: move tags to symbols and cleanup

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-all-devices.yml
+++ b/profiles/kentik_snmp/cisco/cisco-all-devices.yml
@@ -592,6 +592,10 @@ metrics:
           OID: 1.3.6.1.2.1.47.1.1.1.1.13
           name: entPhysicalModelName
         tag: entity_model
+      - column:
+          OID: 1.3.6.1.4.1.9.9.13.1.2.1.2
+          name: ciscoEnvMonVoltageStatusValue
+        tag: voltage_descr
   - MIB: CISCO-ENVMON-MIB
     table:
       OID: 1.3.6.1.4.1.9.9.13
@@ -701,6 +705,10 @@ metrics:
           OID: 1.3.6.1.2.1.47.1.1.1.1.13
           name: entPhysicalModelName
         tag: entity_model
+      - column:
+          OID: 1.3.6.1.4.1.9.9.13.1.4.1.2
+          name: ciscoEnvMonFanStatusDescr
+        tag: fan_descr
   - MIB: CISCO-ENVMON-MIB
     table:
       OID: 1.3.6.1.4.1.9.9.13

--- a/profiles/kentik_snmp/cisco/cisco-all-devices.yml
+++ b/profiles/kentik_snmp/cisco/cisco-all-devices.yml
@@ -128,6 +128,8 @@ metrics:
       OID: 1.3.6.1.4.1.9.9.117.1.1.1
       name: cefcFRUPowerSupplyGroup
     symbols:
+      - OID: 1.3.6.1.4.1.9.9.117.1.1.1.1.3
+        name: cefcTotalAvailableCurrent
       - OID: 1.3.6.1.4.1.9.9.117.1.1.1.1.4
         name: cefcTotalDrawnCurrent
     metric_tags:
@@ -146,10 +148,6 @@ metrics:
       - column:
           OID: 1.3.6.1.4.1.9.9.117.1.1.1.1.2
           name: cefcPowerUnits
-      - column:
-          OID: 1.3.6.1.4.1.9.9.117.1.1.1.1.3
-          name: cefcTotalAvailableCurrent
-        tag: available_current
       - column:
           OID: 1.3.6.1.2.1.47.1.1.1.1.2
           name: entPhysicalDescr
@@ -320,16 +318,10 @@ metrics:
           standbyCdHealthierReset: 21
           nonNativeConfigClearReset: 22
           memoryProtectionErrorReset: 23
-      - OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.4
-        name: cefcModuleStatusLastChangeTime
-      - OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.5
-        name: cefcModuleLastClearConfigTime
       - OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.6
         name: cefcModuleResetReasonDescription
       - OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.7
         name: cefcModuleStateChangeReasonDescr
-      - OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.8
-        name: cefcModuleUpTime
     metric_tags:
       - column:
           OID: 1.3.6.1.2.1.47.1.1.1.1.2
@@ -551,14 +543,120 @@ metrics:
   - MIB: CISCO-ENVMON-MIB
     table:
       OID: 1.3.6.1.4.1.9.9.13
-      name: ciscoEnvMonMIB
+      name: ciscoEnvMonVoltageStatusTable
     symbols:
       - OID: 1.3.6.1.4.1.9.9.13.1.2.1.3
         name: ciscoEnvMonVoltageStatusValue
         tag: voltage_value
+      - OID: 1.3.6.1.4.1.9.9.13.1.2.1.7
+        name: ciscoEnvMonVoltageState
+        enum:
+          normal: 1
+          warning: 2
+          critical: 3
+          shutdown: 4
+          notPresent: 5
+          notFunctioning: 6
+        tag: voltage_state
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.2
+          name: entPhysicalDescr
+        tag: entity_description
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.5
+          name: entPhysicalClass
+          enum:
+            other: 1
+            unknown: 2
+            chassis: 3
+            backplane: 4
+            container: 5
+            powerSupply: 6
+            fan: 7
+            sensor: 8
+            module: 9
+            port: 10
+            stack: 11
+            cpu: 12
+        tag: entity_class
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.7
+          name: entPhysicalName
+        tag: entity_name
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.11
+          name: entPhysicalSerialNum
+        tag: entity_serial
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.13
+          name: entPhysicalModelName
+        tag: entity_model
+  - MIB: CISCO-ENVMON-MIB
+    table:
+      OID: 1.3.6.1.4.1.9.9.13
+      name: ciscoEnvMonTemperatureStatusTable
+    symbols:
       - OID: 1.3.6.1.4.1.9.9.13.1.3.1.3
         name: ciscoEnvMonTemperatureStatusValue
         tag: temp_value
+      - OID: 1.3.6.1.4.1.9.9.13.1.3.1.6
+        name: ciscoEnvMonTemperatureState
+        enum:
+          normal: 1
+          warning: 2
+          critical: 3
+          shutdown: 4
+          notPresent: 5
+          notFunctioning: 6
+        tag: temp_state
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.2
+          name: entPhysicalDescr
+        tag: entity_description
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.5
+          name: entPhysicalClass
+          enum:
+            other: 1
+            unknown: 2
+            chassis: 3
+            backplane: 4
+            container: 5
+            powerSupply: 6
+            fan: 7
+            sensor: 8
+            module: 9
+            port: 10
+            stack: 11
+            cpu: 12
+        tag: entity_class
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.7
+          name: entPhysicalName
+        tag: entity_name
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.11
+          name: entPhysicalSerialNum
+        tag: entity_serial
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.13
+          name: entPhysicalModelName
+        tag: entity_model
+      - column:
+          OID: 1.3.6.1.4.1.9.9.13.1.3.1.2
+          name: ciscoEnvMonTemperatureStatusDescr
+        tag: temp_descr
+      - column:
+          OID: 1.3.6.1.4.1.9.9.13.1.3.1.4
+          name: ciscoEnvMonTemperatureThreshold
+        tag: temp_threshold
+  - MIB: CISCO-ENVMON-MIB
+    table:
+      OID: 1.3.6.1.4.1.9.9.13
+      name: ciscoEnvMonFanStatusTable
+    symbols:
       - OID: 1.3.6.1.4.1.9.9.13.1.4.1.3
         name: ciscoEnvMonFanState
         enum:
@@ -569,6 +667,45 @@ metrics:
           notPresent: 5
           notFunctioning: 6
         tag: fan_state
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.2
+          name: entPhysicalDescr
+        tag: entity_description
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.5
+          name: entPhysicalClass
+          enum:
+            other: 1
+            unknown: 2
+            chassis: 3
+            backplane: 4
+            container: 5
+            powerSupply: 6
+            fan: 7
+            sensor: 8
+            module: 9
+            port: 10
+            stack: 11
+            cpu: 12
+        tag: entity_class
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.7
+          name: entPhysicalName
+        tag: entity_name
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.11
+          name: entPhysicalSerialNum
+        tag: entity_serial
+      - column:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.13
+          name: entPhysicalModelName
+        tag: entity_model
+  - MIB: CISCO-ENVMON-MIB
+    table:
+      OID: 1.3.6.1.4.1.9.9.13
+      name: ciscoEnvMonSupplyStatusTable
+    symbols:
       - OID: 1.3.6.1.4.1.9.9.13.1.5.1.3
         name: ciscoEnvMonSupplyState
         enum:
@@ -614,36 +751,6 @@ metrics:
           name: entPhysicalModelName
         tag: entity_model
       - column:
-          OID: 1.3.6.1.4.1.9.9.13.1.2.1.7
-          name: ciscoEnvMonVoltageState
-          enum:
-            normal: 1
-            warning: 2
-            critical: 3
-            shutdown: 4
-            notPresent: 5
-            notFunctioning: 6
-        tag: voltage_state
-      - column:
-          OID: 1.3.6.1.4.1.9.9.13.1.3.1.2
-          name: ciscoEnvMonTemperatureStatusDescr
-        tag: temp_descr
-      - column:
-          OID: 1.3.6.1.4.1.9.9.13.1.3.1.4
-          name: ciscoEnvMonTemperatureThreshold
-        tag: temp_threshold
-      - column:
-          OID: 1.3.6.1.4.1.9.9.13.1.3.1.6
-          name: ciscoEnvMonTemperatureState
-          enum:
-            normal: 1
-            warning: 2
-            critical: 3
-            shutdown: 4
-            notPresent: 5
-            notFunctioning: 6
-        tag: temp_state
-      - column:
           OID: 1.3.6.1.4.1.9.9.13.1.5.1.4
           name: ciscoEnvMonSupplySource
           enum:
@@ -657,6 +764,8 @@ metrics:
           OID: 1.3.6.1.4.1.9.9.13.1.5.1.2
           name: ciscoEnvMonSupplyStatusDescr
         tag: power_status_description
+
+# Cisco IP SLA functions
   - MIB: CISCO-RTTMON-MIB
     table:
       OID: 1.3.6.1.4.1.9.9.42.1.2.10


### PR DESCRIPTION
Based on customer feedback moving some oids from metric_tags to symbols.
Split up cisco envmon to individual tables instead of creating the meta-table, the potential for confusion is not worth saving a few dozen lines.

Also removed a set of timetick counters that are not actionable within NR