### PR TITLE
chore: removing trailing 0s from scalar OIDs based on customer testing

### DIFF
--- a/profiles/kentik_snmp/barracuda/barracuda-email-gateway.yml
+++ b/profiles/kentik_snmp/barracuda/barracuda-email-gateway.yml
@@ -1,7 +1,6 @@
 # https://campus.barracuda.com/product/emailsecuritygateway/doc/16680139/barracuda-email-security-gateway-snmp-mib/
 # https://campus.barracuda.com/product/websecuritygateway/doc/77401430/snmp-oid-s-for-cpu-memory-and-disk-statistics-on-linux/
-# This profile is linked from the generic Linux SysOID to cover "In Wall" access points
-# https://oidref.com/1.3.6.1.4.1.8072.3.2.10
+# Scalar OIDs in this profile omit the traditional trailing '.0' based on multiple rounds of testing ans SNMP walks
 ---
 extends:
   - if-mib.yml
@@ -17,110 +16,110 @@ metrics:
   # Spam in queue size
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.2.0
+      OID: 1.3.6.1.4.1.20632.2.2
       name: inQueueSize
   # Spam out queue size
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.3.0
+      OID: 1.3.6.1.4.1.20632.2.3
       name: outQueueSize
   # Spam deferred queue size
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.4.0
+      OID: 1.3.6.1.4.1.20632.2.4
       name: deferredQueueSize
   # Spam avg. email latency
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.5.0
+      OID: 1.3.6.1.4.1.20632.2.5
       name: avgEmailLatency
   # Spam out queue size
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.8.0
+      OID: 1.3.6.1.4.1.20632.2.8
       name: notifyQueueSize
   # Time in minutes since last message was delivered
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.11.0
+      OID: 1.3.6.1.4.1.20632.2.11
       name: lastMessageDelivery
   # Number of unique recipients in last 24 hours
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.12.0
+      OID: 1.3.6.1.4.1.20632.2.12
       name: uniqueRecipients
   # Total number of blocked inbound messages
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.20.0
+      OID: 1.3.6.1.4.1.20632.2.20
       name: totalInboundBlocked
   # Total number of inbound messages blocked containing viruses
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.23.0
+      OID: 1.3.6.1.4.1.20632.2.23
       name: totalInboundVirusBlocked
   # Total number of blocked inbound message connections
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.26.0
+      OID: 1.3.6.1.4.1.20632.2.26
       name: totalInboundRateControlled
   # Total number of inbound messages quarantined
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.29.0
+      OID: 1.3.6.1.4.1.20632.2.29
       name: totalInboundQuarantined
   # Total number of tagged inbound messages
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.32.0
+      OID: 1.3.6.1.4.1.20632.2.32
       name: totalInboundTagged
   # Total number of allowed inbound messages
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.35.0
+      OID: 1.3.6.1.4.1.20632.2.35
       name: totalAllowed
   # Total number of outbound messages blocked due to policy violations
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.38.0
+      OID: 1.3.6.1.4.1.20632.2.38
       name: totalOutboundPolicyBlocked
   # Total number of outbound spam messages
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.41.0
+      OID: 1.3.6.1.4.1.20632.2.41
       name: totalOutboundSpamBlocked
   # Total number of outbound messages blocked containing viruses
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.44.0
+      OID: 1.3.6.1.4.1.20632.2.44
       name: totalOutboundVirusBlocked
   # Total number of blocked outbound message connections
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.47.0
+      OID: 1.3.6.1.4.1.20632.2.47
       name: totalOutboundRateControlled
   # Total number of outbound messages quarantined
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.50.0
+      OID: 1.3.6.1.4.1.20632.2.50
       name: totalOutboundQuarantined
   # Total number of messages encrypted
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.53.0
+      OID: 1.3.6.1.4.1.20632.2.53
       name: totalEncrypted
   # Total number of messages redirected
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.56.0
+      OID: 1.3.6.1.4.1.20632.2.56
       name: totalRedirected
   # Total number of outbound messages allowed
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.59.0
+      OID: 1.3.6.1.4.1.20632.2.59
       name: totalSent
   # Number of inbound domains hosted
   - MIB: BARRACUDA-SPAM-MIB
     symbol:
-      OID: 1.3.6.1.4.1.20632.2.62.0
+      OID: 1.3.6.1.4.1.20632.2.62
       name: domainCount


### PR DESCRIPTION
this PR removes the `.0` from the end of all the scalar OIDs in the Barracuda profile based on multiple tests across various devices at a customer account showing that the `SPAM-MIB` doesn't seem to follow the traditional SNMP pattern here.