### PR TITLE
chore: removing extranneous mibs

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-all-devices.yml
+++ b/profiles/kentik_snmp/cisco/cisco-all-devices.yml
@@ -9,10 +9,7 @@
 extends:
   - bgp4-mib.yml
   - if-mib.yml
-  - ip-mib.yml
   - ospf-mib.yml
-  - tcp-mib.yml
-  - udp-mib.yml
 
 metrics:
   - MIB: CISCO-PROCESS-MIB


### PR DESCRIPTION
These extends were inherited from before the beta and have not proven to be useful on Cisco devices.  They generate a pretty significant volume of data and extra load on the polled entities but no customers have expressed an interest in the data.