### PR TITLE
chore: adding nodeName metric_tag for faceting

### DIFF
--- a/profiles/kentik_snmp/netapp/netapp-cluster.yml
+++ b/profiles/kentik_snmp/netapp/netapp-cluster.yml
@@ -1271,6 +1271,10 @@ metrics:
         OID: 1.3.6.1.4.1.789.1.25.2.1.22
         conversion: to_one
     metric_tags:
+      # Node name. Same as sysName for a specific node.
+      - column:
+          name: nodeName
+          OID: 1.3.6.1.4.1.789.1.25.2.1.1
       # Node Product Version. Similar to productVersion for a specific node.
       - column:
           name: nodeProductVersion


### PR DESCRIPTION
resolves #182 

adding `nodeName` to `metric_tags` for the NetApp node table; confirmed with customer the data/OID is valid for their device.