### PR TITLE
chore: update aruba profile to new name

### DIFF
--- a/profiles/kentik_snmp/aruba/aruba-mobility-controller.yml
+++ b/profiles/kentik_snmp/aruba/aruba-mobility-controller.yml
@@ -4,7 +4,7 @@ extends:
   - if-mib.yml
   - system-mib.yml
 
-provider: kentik-mobility-master
+provider: kentik-mobility-controller
 
 sysobjectid:
   - 1.3.6.1.4.1.14823.1.1.50    # ArubaMM-VA


### PR DESCRIPTION
changing name of profile and provider to match new name of devices from vendor; this profile is only used by one customer who is still onboarding so this shouldn't be a breaking change.