### PR TITLE
feat: make ifOperStatus a metric

### DIFF
--- a/profiles/kentik_snmp/_general/if-mib.yml
+++ b/profiles/kentik_snmp/_general/if-mib.yml
@@ -60,7 +60,7 @@ metrics:
       - name: ifOperStatus
         OID: 1.3.6.1.2.1.2.2.1.8
         poll_time_sec: 60
-        tag: ifOperStatusMetric
+        tag: if_OperStatus
         enum:
           up: 1
           down: 2
@@ -324,19 +324,6 @@ metrics:
             up: 1
             down: 2
             testing: 3
-      # The current operational state of the interface.
-      - tag: if_OperStatus
-        column:
-          name: ifOperStatus
-          OID: 1.3.6.1.2.1.2.2.1.8
-          enum:
-            up: 1
-            down: 2
-            testing: 3
-            unknown: 4
-            dormant: 5
-            notPresent: 6
-            lowerLayerDown: 7
       # The textual name of the interface.
       - tag: if_interface_name
         column:

--- a/profiles/kentik_snmp/_general/if-mib.yml
+++ b/profiles/kentik_snmp/_general/if-mib.yml
@@ -60,7 +60,7 @@ metrics:
       - name: ifOperStatus
         OID: 1.3.6.1.2.1.2.2.1.8
         poll_time_sec: 60
-        tag: if_OperStatusMetric
+        tag: ifOperStatusMetric
         enum:
           up: 1
           down: 2

--- a/profiles/kentik_snmp/_general/if-mib.yml
+++ b/profiles/kentik_snmp/_general/if-mib.yml
@@ -56,6 +56,19 @@ metrics:
       # The total number of packets that higher-level protocols requested be transmitted, and which were addressed to a broadcast address at this sub-layer, including those that were discarded or not sent. This object is a 64-bit version of ifOutBroadcastPkts.
       - name: ifHCOutBroadcastPkts
         OID: 1.3.6.1.2.1.31.1.1.1.13
+      # The current operational state of the interface. Note this is both a metric and tag.
+      - name: ifOperStatus
+        OID: 1.3.6.1.2.1.2.2.1.8
+        poll_time_sec: 60
+        tag: if_OperStatusMetric
+        enum:
+          up: 1
+          down: 2
+          testing: 3
+          unknown: 4
+          dormant: 5
+          notPresent: 6
+          lowerLayerDown: 7
     metric_tags:
       # A unique value, greater than zero, for each interface.
       - tag: if_Index

--- a/profiles/kentik_snmp/_general/if32-mib.yml
+++ b/profiles/kentik_snmp/_general/if32-mib.yml
@@ -66,6 +66,19 @@ metrics:
       - name: ifOutBroadcastPkts
         OID: 1.3.6.1.2.1.31.1.1.1.5
         tag: ifHCOutBroadcastPkts
+      # The current operational state of the interface. Note this is both a metric and tag.
+      - name: ifOperStatus
+        OID: 1.3.6.1.2.1.2.2.1.8
+        poll_time_sec: 60
+        tag: ifOperStatusMetric
+        enum:
+          up: 1
+          down: 2
+          testing: 3
+          unknown: 4
+          dormant: 5
+          notPresent: 6
+          lowerLayerDown: 7
 
     metric_tags:
       # A unique value, greater than zero, for each interface.

--- a/profiles/kentik_snmp/_general/if32-mib.yml
+++ b/profiles/kentik_snmp/_general/if32-mib.yml
@@ -70,7 +70,7 @@ metrics:
       - name: ifOperStatus
         OID: 1.3.6.1.2.1.2.2.1.8
         poll_time_sec: 60
-        tag: ifOperStatusMetric
+        tag: if_OperStatus
         enum:
           up: 1
           down: 2
@@ -335,19 +335,6 @@ metrics:
             up: 1
             down: 2
             testing: 3
-      # The current operational state of the interface.
-      - tag: if_OperStatus
-        column:
-          name: ifOperStatus
-          OID: 1.3.6.1.2.1.2.2.1.8
-          enum:
-            up: 1
-            down: 2
-            testing: 3
-            unknown: 4
-            dormant: 5
-            notPresent: 6
-            lowerLayerDown: 7
       # The textual name of the interface.
       - tag: if_interface_name
         column:


### PR DESCRIPTION
This incorporates Ian's feedback to make `ifOperStatus` both a metric and a tag. This change polls `ifOperStatus` every 60 seconds and sends that through as a metric. In doing so it will preserve backwards compatibility and should address the issue where there was an 18 hour delay before `ifOperStatus` changed from "up" to "down".