### PR TITLE
Fixing builds on go 1.18

### DIFF
--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.2'
+          go-version: '1.18.3'
 
       - name: Install dependencies
         run: sudo apt-get install make libpcap-dev


### PR DESCRIPTION
This should fix profile checks. 