### PR TITLE
Create traps.yml

### DIFF
--- a/profiles/kentik_snmp/cisco/traps.yml
+++ b/profiles/kentik_snmp/cisco/traps.yml
@@ -1,0 +1,102 @@
+# Cisco SNMP traps
+---
+
+traps:
+  # Generic SNMP traps
+  # https://oidref.com/static/circitor/SNMPv2-MIB.mib
+  - trap_oid: 1.3.6.1.6.3.1.1.5.1
+    trap_name: coldStart
+    drop_undefined: false
+  - trap_oid: 1.3.6.1.6.3.1.1.5.2
+    trap_name: warmStart
+    drop_undefined: false
+  - trap_oid: 1.3.6.1.6.3.1.1.5.3
+    trap_name: linkDown
+    drop_undefined: false
+  - trap_oid: 1.3.6.1.6.3.1.1.5.4
+    trap_name: linkUp
+    drop_undefined: false
+  - trap_oid: 1.3.6.1.6.3.1.1.5.5
+    trap_name: authenticationFailure
+    drop_undefined: false
+    events:
+      - name: cExtSnmpTargetAuthInetType
+        OID: 1.3.6.1.4.1.9.9.412.1.1.1.0
+        enum:
+          unknown: 0
+          ipv4: 1
+          ipv6: 2
+          dns: 16
+      - name: cExtSnmpTargetAuthInetAddr
+        OID: 1.3.6.1.4.1.9.9.412.1.1.2.0
+  - trap_oid: 1.3.6.1.6.3.1.1.5.6
+    trap_name: authenticationFailure
+    drop_undefined: false
+
+  # https://mibs.observium.org/mib/CISCO-SYSLOG-MIB/
+  - trap_oid: 1.3.6.1.4.1.9.9.41.2.0.1
+    trap_name: clogMessageGenerated
+    drop_undefined: false
+    events:
+      - name: clogHistFacility
+        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.2
+      - name: clogHistSeverity
+        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.3
+      - name: clogHistMsgName 	
+        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.4
+      - name: clogHistMsgText
+        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.5
+      - name: clogHistTimestamp
+        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.6
+
+  # https://oidref.com/static/circitor/CISCO-CONFIG-MAN-MIB.mib
+  - trap_oid: 1.3.6.1.4.1.9.9.43.2.0.1
+    trap_name: ciscoConfigManEvent
+    drop_undefined: false
+    events:
+      - name: ccmHistoryEventCommandSource
+        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.3
+        enum:
+          commandLine: 1
+          snmp: 2
+      - name: ccmHistoryEventConfigSource
+        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.4
+        enum:
+          erase: 1
+          commandSource: 2
+          running: 3
+          startup: 4
+          local: 5
+          networkTftp: 6
+          networkRcp: 7
+          networkFtp: 8
+          networkScp: 9
+      - name: ccmHistoryEventConfigDestination
+        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.5
+        enum:
+          erase: 1
+          commandSource: 2
+          running: 3
+          startup: 4
+          local: 5
+          networkTftp: 6
+          networkRcp: 7
+          networkFtp: 8
+          networkScp: 9
+
+  # https://oidref.com/static/circitor/CISCO-CONFIG-MAN-MIB.mib
+  - trap_oid: 1.3.6.1.4.1.9.9.43.2.0.2
+    trap_name: ccmCLIRunningConfigChanged
+    drop_undefined: false
+    events:
+      - name: ccmHistoryRunningLastChanged
+        OID: 1.3.6.1.4.1.9.9.43.1.1.1.0
+      - name: ccmHistoryEventTerminalType
+        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.6.3
+        enum:
+          notApplicable: 1
+          unknown: 2
+          console: 3
+          terminal: 4
+          virtual: 5
+          auxiliary: 6

--- a/profiles/kentik_snmp/cisco/traps.yml
+++ b/profiles/kentik_snmp/cisco/traps.yml
@@ -4,15 +4,19 @@
 traps:
   # Generic SNMP traps
   # https://oidref.com/static/circitor/SNMPv2-MIB.mib
+  # need to see an example of this one to build the events/varbinds
   - trap_oid: 1.3.6.1.6.3.1.1.5.1
     trap_name: coldStart
     drop_undefined: false
+  # need to see an example of this one to build the events/varbinds
   - trap_oid: 1.3.6.1.6.3.1.1.5.2
     trap_name: warmStart
     drop_undefined: false
+  # need to see an example of this one to build the events/varbinds
   - trap_oid: 1.3.6.1.6.3.1.1.5.3
     trap_name: linkDown
     drop_undefined: false
+  # need to see an example of this one to build the events/varbinds
   - trap_oid: 1.3.6.1.6.3.1.1.5.4
     trap_name: linkUp
     drop_undefined: false
@@ -29,6 +33,7 @@ traps:
           dns: 16
       - name: cExtSnmpTargetAuthInetAddr
         OID: 1.3.6.1.4.1.9.9.412.1.1.2.0
+  # need to see an example of this one to build the events/varbinds
   - trap_oid: 1.3.6.1.6.3.1.1.5.6
     trap_name: authenticationFailure
     drop_undefined: false

--- a/profiles/kentik_snmp/cisco/traps.yml
+++ b/profiles/kentik_snmp/cisco/traps.yml
@@ -44,28 +44,30 @@ traps:
     drop_undefined: false
     events:
       - name: clogHistFacility
-        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.2
+        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.2.*
       - name: clogHistSeverity
-        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.3
+        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.3.*
       - name: clogHistMsgName 	
-        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.4
+        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.4.*
       - name: clogHistMsgText
-        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.5
+        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.5.*
       - name: clogHistTimestamp
-        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.6
+        OID: 1.3.6.1.4.1.9.9.41.1.2.3.1.6.*
 
   # https://oidref.com/static/circitor/CISCO-CONFIG-MAN-MIB.mib
   - trap_oid: 1.3.6.1.4.1.9.9.43.2.0.1
     trap_name: ciscoConfigManEvent
     drop_undefined: false
     events:
+      # The source of the command that instigated the event.
       - name: ccmHistoryEventCommandSource
-        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.3
+        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.3.*
         enum:
           commandLine: 1
           snmp: 2
+      # The configuration data source for the event.
       - name: ccmHistoryEventConfigSource
-        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.4
+        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.4.*
         enum:
           erase: 1
           commandSource: 2
@@ -76,8 +78,9 @@ traps:
           networkRcp: 7
           networkFtp: 8
           networkScp: 9
+      # 	The configuration data destination for the event.
       - name: ccmHistoryEventConfigDestination
-        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.5
+        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.5.*
         enum:
           erase: 1
           commandSource: 2
@@ -88,16 +91,21 @@ traps:
           networkRcp: 7
           networkFtp: 8
           networkScp: 9
+      # If ccmHistoryEventCommandSource is 'commandLine', the name of the logged in user. The length is zero if not available or not applicable.
+      - name: ccmHistoryEventTerminalUser
+        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.8.*
 
   # https://oidref.com/static/circitor/CISCO-CONFIG-MAN-MIB.mib
   - trap_oid: 1.3.6.1.4.1.9.9.43.2.0.2
     trap_name: ccmCLIRunningConfigChanged
     drop_undefined: false
     events:
+      # The value of sysUpTime when the running configuration was last changed.
       - name: ccmHistoryRunningLastChanged
         OID: 1.3.6.1.4.1.9.9.43.1.1.1.0
+      # If ccmHistoryEventCommandSource is 'commandLine', the terminal type, otherwise 'notApplicable'.
       - name: ccmHistoryEventTerminalType
-        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.6.3
+        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.6.*
         enum:
           notApplicable: 1
           unknown: 2
@@ -105,3 +113,53 @@ traps:
           terminal: 4
           virtual: 5
           auxiliary: 6
+      # If ccmHistoryEventCommandSource is 'commandLine', the name of the logged in user. The length is zero if not available or not applicable.
+      - name: ccmHistoryEventTerminalUser
+        OID: 1.3.6.1.4.1.9.9.43.1.1.6.1.8.*
+
+  # https://oidref.com/static/circitor/CISCO-CONFIG-MAN-MIB.mib
+  # A tty trap signifies that a TCP connection, previously established with the sending protocol entity for the purposes of a tty session, has been terminated.
+  - trap_oid: 1.3.6.1.4.1.9.0.1
+    trap_name: tcpConnectionClose
+    drop_undefined: false
+    events:
+      # The state of this TCP connection.
+      - name: tcpConnState
+        OID: 1.3.6.1.2.1.6.13.1.1.*
+        enum:
+          closed: 1
+          listen: 2
+          synSent: 3
+          synReceived: 4
+          established: 5
+          finWait1: 6
+          finWait2: 7
+          closeWait: 8
+          lastAck: 9
+          closing: 10
+          timeWait: 11
+          deleteTCB: 12
+      # Bytes input for this TCP connection
+      - name: loctcpConnInBytes
+        OID: 1.3.6.1.4.1.9.2.6.1.1.1.*
+      # Bytes output for this TCP connection
+      - name: loctcpConnOutBytes
+        OID: 1.3.6.1.4.1.9.2.6.1.1.2.*
+      # How long this TCP connection has been established
+      - name: loctcpConnElapsed
+        OID: 1.3.6.1.4.1.9.2.6.1.1.5.*
+      # Type of session
+      - name: tslineSesType
+        OID: 1.3.6.1.4.1.9.2.9.3.1.1.*
+        enum:
+          unknown: 1
+          pad: 2
+          stream: 3
+          rlogin: 4
+          telnet: 5
+          tcp: 6
+          lat: 7
+          mop: 8
+          slip: 9
+          xremote: 10
+          rshell: 11

--- a/profiles/kentik_snmp/kemp/traps.yml
+++ b/profiles/kentik_snmp/kemp/traps.yml
@@ -3,18 +3,54 @@
 # This profile is created without sample data and may need to be edited in the future.
 ---
 traps:
-  - trap_oid: 1.3.6.1.4.1.12196.13.3.1
-    trap_name: b100Notifications
+  - trap_oid: 1.3.6.1.4.1.12196.13.3.1.1
+    trap_name: vSstateChange
+    drop_undefined: false
     events:
-      # The notification sent when a Virtual Service changes state.
-      - name: vSstateChange
-        OID: 1.3.6.1.4.1.12196.13.3.1.1
-      # The notification sent when a Real Server changes state.
-      - name: rSstateChange
-        OID: 1.3.6.1.4.1.12196.13.3.1.2
-      # The notification sent when a failover occurs.
-      - name: hAstateChange
-        OID: 1.3.6.1.4.1.12196.13.3.1.3
-      # The notification sent when a timed license has expired.
-      - name: licenseExceeded
-        OID: 1.3.6.1.4.1.12196.13.3.1.4
+      - name: vSidx
+        OID: 1.3.6.1.4.1.12196.13.1.1.1
+      - name: vSip
+        OID: 1.3.6.1.4.1.12196.13.1.1.2
+      - name: vSport
+        OID: 1.3.6.1.4.1.12196.13.1.1.3
+      - name: vSaddrtype 
+        OID: 1.3.6.1.4.1.12196.13.1.1.4
+      - name: vSname
+        OID: 1.3.6.1.4.1.12196.13.1.1.13
+      - name: vSstate
+        OID: 1.3.6.1.4.1.12196.13.1.1.14
+
+  - trap_oid: 1.3.6.1.4.1.12196.13.3.1.2
+    trap_name: rSstateChange
+    drop_undefined: false
+    events:
+      - name: rSip 
+        OID: 1.3.6.1.4.1.12196.13.2.1.2
+      - name: rSport
+        OID: 1.3.6.1.4.1.12196.13.2.1.3
+      - name: vSaddrtype 
+        OID: 1.3.6.1.4.1.12196.13.2.1.4
+        enum:
+          unknown: 0
+          ipv4: 1
+          ipv6: 2
+          dns: 16
+      - name: rSidx
+        OID: 1.3.6.1.4.1.12196.13.2.1.5
+      - name: rSstate
+        OID: 1.3.6.1.4.1.12196.13.2.1.8
+        enum:
+          inService: 1
+          outOfService: 2
+          failed: 3
+          disabled: 4
+				  sorry: 5
+				  redirect: 6
+				  errormsg: 7
+
+  - trap_oid: 1.3.6.1.4.1.12196.13.3.1.3
+    trap_name: hAstateChange
+    drop_undefined: false
+  - trap_oid: 1.3.6.1.4.1.12196.13.3.1.4
+    trap_name: licenseExceeded
+    drop_undefined: false

--- a/profiles/kentik_snmp/kemp/traps.yml
+++ b/profiles/kentik_snmp/kemp/traps.yml
@@ -3,54 +3,110 @@
 # This profile is created without sample data and may need to be edited in the future.
 ---
 traps:
-  - trap_oid: 1.3.6.1.4.1.12196.13.3.1.1
-    trap_name: vSstateChange
-    drop_undefined: false
-    events:
-      - name: vSidx
-        OID: 1.3.6.1.4.1.12196.13.1.1.1
-      - name: vSip
-        OID: 1.3.6.1.4.1.12196.13.1.1.2
-      - name: vSport
-        OID: 1.3.6.1.4.1.12196.13.1.1.3
-      - name: vSaddrtype 
-        OID: 1.3.6.1.4.1.12196.13.1.1.4
-      - name: vSname
-        OID: 1.3.6.1.4.1.12196.13.1.1.13
-      - name: vSstate
-        OID: 1.3.6.1.4.1.12196.13.1.1.14
-
   - trap_oid: 1.3.6.1.4.1.12196.13.3.1.2
     trap_name: rSstateChange
-    drop_undefined: false
     events:
-      - name: rSip 
-        OID: 1.3.6.1.4.1.12196.13.2.1.2
-      - name: rSport
-        OID: 1.3.6.1.4.1.12196.13.2.1.3
-      - name: vSaddrtype 
-        OID: 1.3.6.1.4.1.12196.13.2.1.4
+      # Unique VS Id
+      - name: vSidx
+        OID: 1.3.6.1.4.1.12196.13.1.1.1.*
+      # IP address of VS Differented by AddressType
+      - name: vSip
+        OID: 1.3.6.1.4.1.12196.13.1.1.2.*
+      # VS port number
+      - name: vSport
+        OID: 1.3.6.1.4.1.12196.13.1.1.3.*
+      # VS address type
+      - name: vSaddrtype
+        OID: 1.3.6.1.4.1.12196.13.1.1.4.*
         enum:
           unknown: 0
           ipv4: 1
           ipv6: 2
           dns: 16
-      - name: rSidx
-        OID: 1.3.6.1.4.1.12196.13.2.1.5
-      - name: rSstate
-        OID: 1.3.6.1.4.1.12196.13.2.1.8
+      # Name of the VS
+      - name: vSname
+        OID: 1.3.6.1.4.1.12196.13.1.1.13.*
+      # IP address of RS
+      - name: rSip
+        OID: 1.3.6.1.4.1.12196.13.2.1.2.*
+      # RS port number
+      - name: rSport
+        OID: 1.3.6.1.4.1.12196.13.2.1.3.*
+      # RS address type
+      - name: rSaddrtype
+        OID: 1.3.6.1.4.1.12196.13.2.1.4.*
         enum:
-          inService: 1
-          outOfService: 2
-          failed: 3
-          disabled: 4
-          sorry: 5
-          redirect: 6
-          errormsg: 7
+          unknown: 0
+          ipv4: 1
+          ipv6: 2
+          dns: 16
+      # Unique Id of RS
+      - name: rSidx
+        OID: 1.3.6.1.4.1.12196.13.2.1.5.*
+      # current state of RS
+      - name: rSstate
+        OID: 1.3.6.1.4.1.12196.13.2.1.8.*
+        enum:
+          unknown: 0
+          ipv4: 1
+          ipv6: 2
+          dns: 16
 
+  - trap_oid: 1.3.6.1.4.1.12196.13.3.1.2
+    trap_name: rSstateChange
+    drop_undefined: false
+    events:
+      # Unique VS Id
+      - name: vSidx
+        OID: 1.3.6.1.4.1.12196.13.1.1.1.*
+      # IP address of VS Differented by AddressType
+      - name: vSip
+        OID: 1.3.6.1.4.1.12196.13.1.1.2.*
+      # VS port number
+      - name: vSport
+        OID: 1.3.6.1.4.1.12196.13.1.1.3.*
+      # VS address type
+      - name: vSaddrtype
+        OID: 1.3.6.1.4.1.12196.13.1.1.4.*
+        enum:
+          unknown: 0
+          ipv4: 1
+          ipv6: 2
+          dns: 16
+      # Name of the VS
+      - name: vSname
+        OID: 1.3.6.1.4.1.12196.13.1.1.13.*
+      # IP address of RS
+      - name: rSip
+        OID: 1.3.6.1.4.1.12196.13.2.1.2.*
+      # RS port number
+      - name: rSport
+        OID: 1.3.6.1.4.1.12196.13.2.1.3.*
+      # RS address type
+      - name: rSaddrtype
+        OID: 1.3.6.1.4.1.12196.13.2.1.4.*
+        enum:
+          unknown: 0
+          ipv4: 1
+          ipv6: 2
+          dns: 16
+      # Unique Id of RS
+      - name: rSidx
+        OID: 1.3.6.1.4.1.12196.13.2.1.5.*
+      # current state of RS
+      - name: rSstate
+        OID: 1.3.6.1.4.1.12196.13.2.1.8.*
+        enum:
+          unknown: 0
+          ipv4: 1
+          ipv6: 2
+          dns: 16
+
+  # need to see an example of this one to build the events/varbinds
   - trap_oid: 1.3.6.1.4.1.12196.13.3.1.3
     trap_name: hAstateChange
     drop_undefined: false
+  # need to see an example of this one to build the events/varbinds
   - trap_oid: 1.3.6.1.4.1.12196.13.3.1.4
     trap_name: licenseExceeded
     drop_undefined: false

--- a/profiles/kentik_snmp/kemp/traps.yml
+++ b/profiles/kentik_snmp/kemp/traps.yml
@@ -44,9 +44,9 @@ traps:
           outOfService: 2
           failed: 3
           disabled: 4
-				  sorry: 5
-				  redirect: 6
-				  errormsg: 7
+          sorry: 5
+          redirect: 6
+          errormsg: 7
 
   - trap_oid: 1.3.6.1.4.1.12196.13.3.1.3
     trap_name: hAstateChange


### PR DESCRIPTION
@i3149 I wanted to confirm a few things to make sure what I'm doing in here is actually workable in ktranslate.

I've got the OID and names of a few traps from a MIB document I was working from, but I haven't seen any of the varbind oids yet so I was imagining that if we leave drop undefined as false I would at least get the name of the trap and later on we can fill in the events stanza, see lines 7-18 without the events compared to 19-31.  

The other piece I wanted to ask about was that in the packet capture I saw several of the oids were including index numbers of tabular entries, is there some different syntax we need to use to deal with that?  For example the varbind oid would be .1.3.6.1.4.1.12196.13.1.1.1, but a set of 3 incoming traps would come in as .1.3.6.1.4.1.12196.13.1.1.1.8, .1.3.6.1.4.1.12196.13.1.1.1.10, .1.3.6.1.4.1.12196.13.1.1.1.32.