### PR TITLE
chore/system mib cleanup

### DIFF
--- a/profiles/kentik_snmp/_general/system-mib.yml
+++ b/profiles/kentik_snmp/_general/system-mib.yml
@@ -5,16 +5,12 @@ metric_tags:
   - column:
       OID: 1.3.6.1.2.1.1.1.0
       name: sysDescr
-    tag: snmp_sysdesc
   - column:
       OID: 1.3.6.1.2.1.1.2.0
       name: sysObjectID
-    tag: snmp_sysobjectid
   - column:
       OID: 1.3.6.1.2.1.1.5.0
       name: sysName
-    tag: snmp_sysName
   - column:
       OID: 1.3.6.1.2.1.1.6.0
       name: sysLocation
-    tag: snmp_sysLocation

--- a/profiles/kentik_snmp/cisco/cisco-all-devices.yml
+++ b/profiles/kentik_snmp/cisco/cisco-all-devices.yml
@@ -13,6 +13,7 @@ extends:
   - bgp4-mib.yml
   - if-mib.yml
   - ospf-mib.yml
+  - system-mib.yml
 
 metrics:
   # A table of overall CPU statistics.

--- a/profiles/kentik_snmp/cisco/cisco-asa.yml
+++ b/profiles/kentik_snmp/cisco/cisco-asa.yml
@@ -5,7 +5,6 @@
 ---
 extends:
   - cisco-all-devices.yml
-  - system-mib.yml
 
 provider: kentik-firewall
 

--- a/profiles/kentik_snmp/cisco/cisco-asr.yml
+++ b/profiles/kentik_snmp/cisco/cisco-asr.yml
@@ -3,10 +3,6 @@
 # https://www.circitor.fr/Mibs/Html/C/CISCO-PRODUCT-MIB.php
 ---
 extends:
-  - bgp4-mib.yml
-  - if-mib.yml
-  - ospf-mib.yml
-  - system-mib.yml
   - cisco-all-devices.yml
 
 provider: kentik-router

--- a/profiles/kentik_snmp/cisco/cisco-call-manager.yml
+++ b/profiles/kentik_snmp/cisco/cisco-call-manager.yml
@@ -3,7 +3,6 @@
 
 extends: 
   - host-resources-mib.yml
-  - system-mib.yml
   - cisco-all-devices.yml
   
 provider: kentik-call-manager

--- a/profiles/kentik_snmp/cisco/cisco-catalyst.yml
+++ b/profiles/kentik_snmp/cisco/cisco-catalyst.yml
@@ -2,7 +2,6 @@
 # http://oid-info.com/get/1.3.6.1.4.1.9.9.276.1.1.1
 ---
 extends:
-  - system-mib.yml
   - cisco-all-devices.yml
 
 provider: kentik-switch

--- a/profiles/kentik_snmp/cisco/cisco-load-balancer.yml
+++ b/profiles/kentik_snmp/cisco/cisco-load-balancer.yml
@@ -3,7 +3,6 @@
 ---
 extends:
   - cisco-all-devices.yml
-  - system-mib.yml
 
 provider: kentik-load-balancer
 

--- a/profiles/kentik_snmp/cisco/cisco-nexus.yml
+++ b/profiles/kentik_snmp/cisco/cisco-nexus.yml
@@ -2,7 +2,6 @@
 ---
 extends:
   - cisco-all-devices.yml
-  - system-mib.yml
 
 provider: kentik-switch
 

--- a/profiles/kentik_snmp/cisco/cisco-voice.yml
+++ b/profiles/kentik_snmp/cisco/cisco-voice.yml
@@ -5,7 +5,6 @@
 # http://www.circitor.fr/Mibs/Html/D/DIAL-CONTROL-MIB.php
 ---
 extends:
-  - system-mib.yml
   - cisco-all-devices.yml
 
 sysobjectid:

--- a/profiles/kentik_snmp/cisco/cisco-wan-optimizer.yml
+++ b/profiles/kentik_snmp/cisco/cisco-wan-optimizer.yml
@@ -2,7 +2,6 @@
 ---
 extends:
   - cisco-all-devices.yml
-  - system-mib.yml
   - host-resources-mib.yml
 
 provider: kentik-cisco-wan-optimizer

--- a/profiles/kentik_snmp/cisco/cisco-wlc.yml
+++ b/profiles/kentik_snmp/cisco/cisco-wlc.yml
@@ -2,7 +2,6 @@
 ---
 extends:
   - cisco-all-devices.yml
-  - system-mib.yml
   - host-resources-mib.yml
 
 provider: kentik-wireless-controller


### PR DESCRIPTION
This PR sets up `system-mib.yml` to use the raw names of the OIDs in order to maintain standardization for curated UI experiences in the future. 

It also moves the `system-mib.yml` from various profiles in the `/cisco` dir to the `cisco-all-devices.yml` profile to align with the design standard from other vendor profiles.

@jbeveland27 - can you validate the following metric tags are not in use in the UI today before we merge this?

```
snmp_sysdesc
snmp_sysobjectid
snmp_sysName
snmp_sysLocation
```