### PR TITLE
chore: move config params from symbol to tags

### DIFF
--- a/profiles/kentik_snmp/_general/bgp4-mib.yml
+++ b/profiles/kentik_snmp/_general/bgp4-mib.yml
@@ -24,12 +24,6 @@ metrics:
         enum:
           stop: 1
           start: 2
-      # The negotiated version of BGP running between the two peers.
-      - name: bgpPeerNegotiatedVersion
-        OID: 1.3.6.1.2.1.15.3.1.4
-      # The remote autonomous system number.
-      - name: bgpPeerRemoteAs
-        OID: 1.3.6.1.2.1.15.3.1.9
       # The number of BGP UPDATE messages received on this connection.
       - name: bgpPeerInUpdates
         OID: 1.3.6.1.2.1.15.3.1.10
@@ -48,28 +42,51 @@ metrics:
       # This timer indicates how long (in seconds) this peer has been in the Established state or how long since this peer was last in the Established state. It is set to zero when a new peer is configured or the router is booted.
       - name: bgpPeerFsmEstablishedTime
         OID: 1.3.6.1.2.1.15.3.1.16
-      # Time interval in seconds for the ConnectRetry timer.
-      - name: bgpPeerConnectRetryInterval
-        OID: 1.3.6.1.2.1.15.3.1.17
-      # Time interval in seconds for the Hold Timer established with the peer.
-      - name: bgpPeerHoldTime
-        OID: 1.3.6.1.2.1.15.3.1.18
-      # Time interval in seconds for the KeepAlive timer established with the peer.
-      - name: bgpPeerKeepAlive
-        OID: 1.3.6.1.2.1.15.3.1.19
-      # Time interval in seconds for the Hold Time configured for this BGP speaker with this peer.
-      - name: bgpPeerHoldTimeConfigured
-        OID: 1.3.6.1.2.1.15.3.1.20
-      # Time interval in seconds for the KeepAlive timer configured for this BGP speaker with this peer.
-      - name: bgpPeerKeepAliveConfigured
-        OID: 1.3.6.1.2.1.15.3.1.21
-      # Time interval in seconds for the MinASOriginationInterval timer.
-      - name: bgpPeerMinASOriginationInterval
-        OID: 1.3.6.1.2.1.15.3.1.22
+
 
     metric_tags:
+      # The negotiated version of BGP running between the two peers.
+      - tag: negotiated_version
+        column:
+          name: bgpPeerNegotiatedVersion
+          OID: 1.3.6.1.2.1.15.3.1.4
       # The remote IP address of this entry's BGP peer.
       - tag: neighbor_ip
         column:
           name: bgpPeerRemoteAddr
           OID: 1.3.6.1.2.1.15.3.1.7
+      # The remote autonomous system number.
+      - tag: remote_as
+        column:
+          name: bgpPeerRemoteAs
+          OID: 1.3.6.1.2.1.15.3.1.9 
+      # Time interval in seconds for the ConnectRetry timer.
+      - tag: retry_interval
+        column:
+          name: bgpPeerConnectRetryInterval
+          OID: 1.3.6.1.2.1.15.3.1.17
+      # Time interval in seconds for the Hold Timer established with the peer.
+      - tag: hold_time_established
+        column:
+          name: bgpPeerHoldTime
+          OID: 1.3.6.1.2.1.15.3.1.18
+      # Time interval in seconds for the KeepAlive timer established with the peer.
+      - tag: keep_alive_established
+        column:
+          name: bgpPeerKeepAlive
+          OID: 1.3.6.1.2.1.15.3.1.19
+      # Time interval in seconds for the Hold Time configured for this BGP speaker with this peer.
+      - tag: hold_time_configured
+        column:
+          name: bgpPeerHoldTimeConfigured
+          OID: 1.3.6.1.2.1.15.3.1.20
+      # Time interval in seconds for the KeepAlive timer configured for this BGP speaker with this peer.
+      - tag: keep_alive_configured
+        column:
+          name: bgpPeerKeepAliveConfigured
+          OID: 1.3.6.1.2.1.15.3.1.21
+      # Time interval in seconds for the MinASOriginationInterval timer.
+      - tag: min_as_origination_interval
+        column:
+          name: bgpPeerMinASOriginationInterval
+          OID: 1.3.6.1.2.1.15.3.1.22


### PR DESCRIPTION
Upon review several of these data points make more sense as a tag than a metric, they would never change after a peering connection was first established and mostly contain meta data about how the connection was set up.