### PR TITLE
[WIP] fix: poll firewall golden metrics every 60 seconds

### DIFF
--- a/profiles/kentik_snmp/checkpoint/checkpoint-firewall.yml
+++ b/profiles/kentik_snmp/checkpoint/checkpoint-firewall.yml
@@ -22,8 +22,10 @@ metrics:
         name: multiProcSystemTime
       - OID: 1.3.6.1.4.1.2620.1.6.7.5.1.4
         name: multiProcIdleTime
+      # CPU Utilization - polled at 60s to support anomaly detection
       - OID: 1.3.6.1.4.1.2620.1.6.7.5.1.5
         name: multiProcUsage
+        poll_time_sec: 60
     table:
       OID: 1.3.6.1.4.1.2620.1.6.7.5
       name: multiProcTable
@@ -31,6 +33,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.2620.1.6.7.2.7.0
       name: procNum
+  # Memory Utilization - polled at 60s to support anomaly detection
   - MIB: CHECKPOINT-MIB
     symbol:
       OID: 1.3.6.1.4.1.2620.1.6.7.4.3.0
@@ -41,6 +44,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.2620.1.6.7.4.4.0
       name: memActiveReal64
+  # Memory Utilization - polled at 60s to support anomaly detection
   - MIB: CHECKPOINT-MIB
     symbol:
       OID: 1.3.6.1.4.1.2620.1.6.7.4.5.0
@@ -137,10 +141,12 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.2620.1.1.5.0
       name: fwRejected
+  # Sessions Total - polled at 60s to support anomaly detection
   - MIB: CHECKPOINT-MIB
     symbol:
       OID: 1.3.6.1.4.1.2620.1.1.25.3.0
       name: fwNumConn
+      poll_time_sec: 60
   - MIB: CHECKPOINT-MIB
     symbol:
       OID: 1.3.6.1.4.1.2620.1.1.25.4.0

--- a/profiles/kentik_snmp/cisco/cisco-asa.yml
+++ b/profiles/kentik_snmp/cisco/cisco-asa.yml
@@ -182,10 +182,12 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.9.9.392.1.4.1.2.0
       name: crasNumDeclinedSessions
+  # Sessions Total - polled at 60s to support anomaly detection
   - MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
     symbol:
       OID: 1.3.6.1.4.1.9.9.392.1.3.1.0
       name: crasNumSessions
+      poll_time_sec: 60
   - MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
     symbol:
       OID: 1.3.6.1.4.1.9.9.392.1.3.3.0

--- a/profiles/kentik_snmp/cisco/cisco-firepower.yml
+++ b/profiles/kentik_snmp/cisco/cisco-firepower.yml
@@ -22,11 +22,13 @@ metrics:
       OID: 1.3.6.1.4.1.9.9.109.1.1.1
       name: cpmCPUTotalTable
     symbols:
+      # CPU Utilization - polled at 60s to support anomaly detection
       # The overall CPU busy percentage in the last 1 minute period.
       - OID: 1.3.6.1.4.1.9.9.109.1.1.1.1.7
         name: cpmCPUTotal1minRev
         tag: CPU
         poll_time_sec: 60
+  # Memory Utilization - polled at 60s to support anomaly detection
   # Indicates the number of bytes from the memory pool that are currently in use by applications on the physical entity. This object is a 64-bit version of cempMemPoolUsed.
   - MIB: CISCO-ENHANCED-MEMPOOL-MIB
     symbol:
@@ -34,6 +36,7 @@ metrics:
       name: cempMemPoolHCUsed
       tag: MemoryUsed
       poll_time_sec: 60
+  # Memory Utilization - polled at 60s to support anomaly detection
   # Indicates the number of bytes from the memory pool that are currently unused on the physical entity. This object is a 64-bit version of cempMemPoolFree.
   - MIB: CISCO-ENHANCED-MEMPOOL-MIB
     symbol:
@@ -41,8 +44,10 @@ metrics:
       name: cempMemPoolHCFree
       tag: MemoryFree
       poll_time_sec: 60
+  # Sessions Total - polled at 60s to support anomaly detection
   # The number of currently active sessions.
   - MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
     symbol:
       OID: 1.3.6.1.4.1.9.9.392.1.3.1.0
       name: crasNumSessions
+      poll_time_sec: 60

--- a/profiles/kentik_snmp/dell/sonicwall-sma.yml
+++ b/profiles/kentik_snmp/dell/sonicwall-sma.yml
@@ -31,11 +31,13 @@ metrics:
     symbol:
       name: maximumLicensedUsers
       OID: 1.3.6.1.4.1.8741.8.1.2.1.3.0
+  # Sessions Total - polled at 60s to support anomaly detection
   # The number of connections currently being serviced by the appliance ( or cluster of appliances).
   - MIB: SONICWALL-SMA-APPLIANCE-SYSTEM-HEALTH-MIB
     symbol:
       name: currentConnections
       OID: 1.3.6.1.4.1.8741.8.1.2.2.1.0
+      poll_time_sec: 60
   # The maximum number of concurrent appliance connections since the last reset; where reset interval is 24 hours.
   - MIB: SONICWALL-SMA-APPLIANCE-SYSTEM-HEALTH-MIB
     symbol:

--- a/profiles/kentik_snmp/dell/sonicwall.yml
+++ b/profiles/kentik_snmp/dell/sonicwall.yml
@@ -12,7 +12,7 @@ provider: kentik-firewall
 
 metrics:
   # Instantaneous CPU Utilization in percent
-  # Polled at 60s to support anomaly detection
+  # CPU Utilization - polled at 60s to support anomaly detection
   - MIB: SONICWALL-FIREWALL-IP-STATISTICS-MIB
     symbol:
       name: sonicCurrentCPUUtil
@@ -20,7 +20,7 @@ metrics:
       poll_time_sec: 60
       tag: CPU
   # Instantaneous RAM Utilization in percent
-  # Polled at 60s to support anomaly detection
+  # Memory Utilization - polled at 60s to support anomaly detection
   - MIB: SONICWALL-FIREWALL-IP-STATISTICS-MIB
     symbol:
       name: sonicCurrentRAMUtil

--- a/profiles/kentik_snmp/fortinet/fortinet-fortigate.yml
+++ b/profiles/kentik_snmp/fortinet/fortinet-fortigate.yml
@@ -15,8 +15,10 @@ metrics:
       OID: 1.3.6.1.4.1.12356.101.4.1
       name: fgSystemInfo
     symbols:
+      # CPU Utilization - polled at 60s to support anomaly detection
       - OID: 1.3.6.1.4.1.12356.101.4.1.3.0
         name: fgSysCpuUsage
+        poll_time_sec: 60
   - MIB: FORTINET-FORTIGATE-MIB
     table:
       OID: 1.3.6.1.4.1.12356.101.4.4.2
@@ -38,15 +40,20 @@ metrics:
         name: fgProcessorUsage
       - OID: 1.3.6.1.4.1.12356.101.4.4.2.1.10
         name: fgProcessorSysUsage
-
+  # Memory Utilization - polled at 60s to support anomaly detection
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.4.0
       name: fgSysMemUsage
+      poll_time_sec: 60
+      tag: MemoryUsed
+  # Memory Utilization - polled at 60s to support anomaly detection
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.5.0
       name: fgSysMemCapacity
+      poll_time_sec: 60
+      tag: MemoryTotal
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.9.0
@@ -118,18 +125,22 @@ metrics:
           name: ifName
         table: ifXTable
         tag: if_interface_name
+  # Sessions Total - polled at 60s to support anomaly detection
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.8.0
       name: fgSysSesCount
+      poll_time_sec: 60
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.11.0
       name: fgSysSesRate1
+  # Sessions Total - polled at 60s to support anomaly detection
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.15.0
       name: fgSysSes6Count
+      poll_time_sec: 60
   - MIB: FORTINET-FORTIGATE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12356.101.4.1.16.0

--- a/profiles/kentik_snmp/juniper/pulse-secure.yml
+++ b/profiles/kentik_snmp/juniper/pulse-secure.yml
@@ -23,12 +23,14 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.12532.3.0
       name: signedInMailUsers
+  # CPU Utilization - polled at 60s to support anomaly detection
   - MIB: JUNIPER-IVE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12532.10.0
       name: iveCpuUtil
       poll_time_sec: 60
       tag: CPU
+  # Memory Utilization - polled at 60s to support anomaly detection
   - MIB: JUNIPER-IVE-MIB
     symbol:
       OID: 1.3.6.1.4.1.12532.11.0

--- a/profiles/kentik_snmp/palo_alto/palo-alto.yml
+++ b/profiles/kentik_snmp/palo_alto/palo-alto.yml
@@ -3,7 +3,6 @@
 extends:
   - system-mib.yml
   - if-mib.yml
-  - host-resources-mib.yml
   - ospf-mib.yml
   - entity-sensor-mib.yml
 
@@ -12,14 +11,92 @@ provider: kentik-firewall
 sysobjectid: 1.3.6.1.4.1.25461.2.3.*
 
 metrics:
+  # Memory Utilization - polled at 60s to support anomaly detection
+  - MIB: HOST-RESOURCES-MIB
+    symbol:
+      name: hrStorageSizeRAM
+      OID: 1.3.6.1.2.1.25.2.3.1.5.1
+      poll_time_sec: 60
+      tag: MemoryTotal
+  # Memory Utilization - polled at 60s to support anomaly detection
+  - MIB: HOST-RESOURCES-MIB
+    symbol:
+      name: hrStorageUsedRAM
+      OID: 1.3.6.1.2.1.25.2.3.1.6.100
+      poll_time_sec: 60
+      tag: MemoryUsed
+
+  - MIB: HOST-RESOURCES-MIB
+    table:
+      OID: 1.3.6.1.2.1.25.3.3
+      name: hrProcessorTable
+    symbols:
+      # CPU Utilization - polled at 60s to support anomaly detection
+      - OID: 1.3.6.1.2.1.25.3.3.1.2
+        name: hrProcessorLoad
+        poll_time_sec: 60
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.2.1.25.3.2.1.3
+          name: hrDeviceDescr
+        tag: processor_description
+
+  # All other metrics from host-resources-mib
+  - MIB: HOST-RESOURCES-MIB
+    symbols:
+      - OID: 1.3.6.1.2.1.25.1.1.0
+        name: hrSystemUptime
+      - OID: 1.3.6.1.2.1.25.1.5.0
+        name: hrSystemNumUsers
+      - OID: 1.3.6.1.2.1.25.1.6.0
+        name: hrSystemProcesses
+      - OID: 1.3.6.1.2.1.25.1.7.0
+        name: hrSystemMaxProcesses
+  - MIB: HOST-RESOURCES-MIB
+    table:
+      OID: 1.3.6.1.2.1.25.2.3
+      name: hrStorageTable
+    symbols:
+      - OID: 1.3.6.1.2.1.25.2.3.1.4
+        name: hrStorageAllocationUnits
+      - OID: 1.3.6.1.2.1.25.2.3.1.5
+        name: hrStorageSize
+      - OID: 1.3.6.1.2.1.25.2.3.1.6
+        name: hrStorageUsed
+      - OID: 1.3.6.1.2.1.25.2.3.1.7
+        name: hrStorageAllocationFailures
+    metric_tags:
+      - tag: storage_description
+        column:
+          OID: 1.3.6.1.2.1.25.2.3.1.3
+          name: hrStorageDescr
+      - tag: storage_type
+        column:
+          OID: 1.3.6.1.2.1.25.2.3.1.2
+          name: hrStorageType
+          enum:
+            Other: 1
+            Ram: 2
+            VirtualMemory: 3
+            FixedDisk: 4
+            RemovableDisk: 5
+            FloppyDisk: 6
+            CompactDisc: 7
+            RamDisk: 8
+            FlashMemory: 9
+            NetworkDisk: 10
+
+  # MIB for the common MIB objects implemented by all Palo Alto devices.
   - MIB: PAN-COMMON-MIB
     symbols:
       - OID: 1.3.6.1.4.1.25461.2.1.2.3.1.0
         name: panSessionUtilization
       - OID: 1.3.6.1.4.1.25461.2.1.2.3.2.0
         name: panSessionMax
+      # Sessions Total - polled at 60s to support anomaly detection
       - OID: 1.3.6.1.4.1.25461.2.1.2.3.3.0
         name: panSessionActive
+        poll_time_sec: 60
       - OID: 1.3.6.1.4.1.25461.2.1.2.3.4.0
         name: panSessionActiveTcp
       - OID: 1.3.6.1.4.1.25461.2.1.2.3.5.0

--- a/profiles/kentik_snmp/sophos/xgs-firewall.yml
+++ b/profiles/kentik_snmp/sophos/xgs-firewall.yml
@@ -52,11 +52,13 @@ metrics:
     symbol:
       name: sfosSwapPercentUsage
       OID: 1.3.6.1.4.1.2604.5.1.2.5.4.0
+  # Sessions Total - polled at 60s to support anomaly detection
   # Display live user count login into captive portal
   - MIB: SFOS-FIREWALL-MIB
     symbol:
       name: sfosLiveUsersCount
       OID: 1.3.6.1.4.1.2604.5.1.2.6.0
+      poll_time_sec: 60
   # Counters to show hits to various TCP Protocols
   - MIB: SFOS-FIREWALL-MIB
     symbol:


### PR DESCRIPTION
This aligns all of the firewall profiles to poll golden metrics every 60 seconds. 

Also fixes specific issues `fortinet-fortigate` had with `Memory Utilization` golden metrics by tagging `fgSysMemUsage` and `fgSysMemCapacity`. A corresponding PR to entity-definitions will follow.