### PR TITLE
Feat add 3com huawei

### DIFF
--- a/profiles/kentik_snmp/3com/3com-huawei.yml
+++ b/profiles/kentik_snmp/3com/3com-huawei.yml
@@ -1,0 +1,64 @@
+# https://www.circitor.fr/Mibs/Html/A/A3COM-HUAWEI-LswDEVM-MIB.php
+---
+extends:
+  - system-mib.yml
+  - if-mib.yml
+
+provider: kentik-switch
+
+sysobjectid:
+  - 1.3.6.1.4.1.43.45*         # 3com-Huawei
+
+metrics:
+  - MIB: A3COM-HUAWEI-LswDEVM-MIB
+    table:
+      name: hwCpuTable 
+      OID: 1.3.6.1.4.1.43.45.1.6.1.1
+    symbols:
+      # The overall CPU cost percentage in the last 1 minute period.
+      - name: hwCpuCostRatePer1Min
+        OID: 1.3.6.1.4.1.43.45.1.6.1.1.1.3
+        poll_time_sec: 60
+        tag: CPU
+
+  - MIB: A3COM-HUAWEI-LswDEVM-MIB
+    table:
+      name: hwMemTable 
+      OID: 1.3.6.1.4.1.43.45.1.6.1.2.1
+    symbols:
+      # Indicates the total size of the memory module which is on the managed object.
+      - name: hwMemSize
+        OID: 1.3.6.1.4.1.43.45.1.6.1.2.1.1.2
+        poll_time_sec: 60
+        tag: MemoryTotal
+      # Indicates the total size of the memory module which is on the managed object.
+      - name: hwMemFree
+        OID: 1.3.6.1.4.1.43.45.1.6.1.2.1.1.3
+        poll_time_sec: 60
+        tag: MemoryFree
+
+  - MIB: A3COM-HUAWEI-LswDEVM-MIB
+    table:
+      name: hwdevMFanStatusTable 
+      OID: 1.3.6.1.4.1.43.45.1.2.23.1.9.1.1
+    symbols:
+      - name: hwDevMFanStatus
+        OID: 1.3.6.1.4.1.43.45.1.2.23.1.9.1.1.1.2
+        enum:
+          active: 1
+          deactive: 2
+          notInstalled: 3
+          unsupported: 4
+
+  - MIB: A3COM-HUAWEI-LswDEVM-MIB
+    table:
+      name: hwdevMPowerStatusTable 
+      OID: 1.3.6.1.4.1.43.45.1.2.23.1.9.1.2
+    symbols:
+      - name: hwDevMPowerStatus
+        OID: 1.3.6.1.4.1.43.45.1.2.23.1.9.1.2.1.2
+        enum:
+          active: 1
+          deactive: 2
+          notInstalled: 3
+          unsupported: 4

--- a/profiles/kentik_snmp/3com/3com.yml
+++ b/profiles/kentik_snmp/3com/3com.yml
@@ -1,0 +1,12 @@
+# https://oidref.com/1.3.6.1.4.1.43.1.8
+# No CPU or memory OID appears to be available for this product line, this profile just collects interface data and moves the 3com devices to the switch category
+---
+extends:
+  - system-mib.yml
+  - if-mib.yml
+
+
+provider: kentik-switch
+
+sysobjectid:
+  - 1.3.6.1.4.1.43.1.8.*         # 3com


### PR DESCRIPTION
customer supplied walk from #451 shows no useful OID's beside the IF-MIB, but this pr contains a profile that at least moves this device into the switch category.

While researching I came across a MIB that was known to work for a different 3com product line so I added it while i was in there.