### PR TITLE
chore/infoblox

### DIFF
--- a/profiles/kentik_snmp/infoblox/infoblox-ipam.yml
+++ b/profiles/kentik_snmp/infoblox/infoblox-ipam.yml
@@ -229,6 +229,7 @@ metric_tags:
   - column:
       name: ibSerialNumber
       OID: 1.3.6.1.4.1.7779.3.1.1.2.1.6.0
+    tag: serial_number
   # Infoblox One NIOS version
   - column:
       name: ibNiosVersion

--- a/profiles/kentik_snmp/infoblox/infoblox-ipam.yml
+++ b/profiles/kentik_snmp/infoblox/infoblox-ipam.yml
@@ -112,6 +112,31 @@ metrics:
       - column:
           name: ibBindZoneName
           OID: 1.3.6.1.4.1.7779.3.1.1.3.1.1.1.1
+  # Number of successful dynamic DNS update.
+  - MIB: IB-DNSONE-MIB
+    symbol:
+      name: ibDDNSUpdateSuccess
+      OID: 1.3.6.1.4.1.7779.3.1.1.3.1.3.1.0
+  # Number of failure dynamic DNS update.
+  - MIB: IB-DNSONE-MIB
+    symbol:
+      name: ibDDNSUpdateFailure
+      OID: 1.3.6.1.4.1.7779.3.1.1.3.1.3.2.0
+  # Number of dynamic DNS update rejects maybe due to permission failure.
+  - MIB: IB-DNSONE-MIB
+    symbol:
+      name: ibDDNSUpdateReject
+      OID: 1.3.6.1.4.1.7779.3.1.1.3.1.3.3.0
+  # Number of dynamic DNS update rejects due to prerequisite failure.
+  - MIB: IB-DNSONE-MIB
+    symbol:
+      name: ibDDNSUpdatePrerequisiteReject
+      OID: 1.3.6.1.4.1.7779.3.1.1.3.1.3.4.0
+  # DNS queries per second
+  - MIB: IB-DNSONE-MIB
+    symbol:
+      name: ibDnsQueryRate
+      OID: 1.3.6.1.4.1.7779.3.1.1.3.1.6.0
   # A table of Physical Node's Grid Replication Status.
   - MIB: IB-PLATFORMONE-MIB
     table:


### PR DESCRIPTION
resolves #482 

also adds `tag: serial_number` to the metric tags to align with the standard; verified the entity def doesn't use serial currently so this is not a breaking change