### PR TITLE
Fix: Allow duplicates for nexus CPU

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-all-devices.yml
+++ b/profiles/kentik_snmp/cisco/cisco-all-devices.yml
@@ -28,6 +28,7 @@ metrics:
         OID: 1.3.6.1.4.1.9.9.109.1.1.1.1.7
         poll_time_sec: 60
         tag: CPU
+        allow_duplicate: true
 
   # A table of memory pool monitoring entries.
   # Polled at 60s to support anomaly detection.

--- a/profiles/kentik_snmp/cisco/cisco-nexus.yml
+++ b/profiles/kentik_snmp/cisco/cisco-nexus.yml
@@ -102,6 +102,7 @@ metrics:
       OID: 1.3.6.1.4.1.9.9.305.1.1.1.0
       name: cseSysCPUUtilization
       poll_time_sec: 60
+      allow_duplicate: true
   - MIB: CISCO-SYSTEM-EXT-MIB
     symbol:
       OID: 1.3.6.1.4.1.9.9.305.1.1.2.0


### PR DESCRIPTION
Taking advantage of the allow_duplicates feature to get nexus and all other cisco devices back in sync.