### PR TITLE
Create omron-cj-ethernet-ip.yml

### DIFF
--- a/profiles/kentik_snmp/omron/omron-cj-ethernet-ip.yml
+++ b/profiles/kentik_snmp/omron/omron-cj-ethernet-ip.yml
@@ -1,0 +1,12 @@
+# https://assets.omron.eu/downloads/manual/en/w495_cj-series_ethernet_ip_units_for_nj-series_operation_manual_en.pdf
+# This hardware does not support much beyond the System and IF-MIBs and does not provide CPU and Memory via SNMP
+---
+extends:
+  - system-mib.yml
+  - if-mib.yml
+
+provider: kentik-appliance
+
+sysobjectid:
+  - 1.3.6.1.4.1.16838.1.*              # Omron
+  - 1.3.6.1.4.1.16838.1.1025.5         # Omron Ethernet-IP Unit


### PR DESCRIPTION
Resolves #553 

Note that this device provides very minimal data via generic SNMP MIBs and does not have a vendor specific MIB, per their documentation.