### PR TITLE
fix: possible solution for invalid enum

### DIFF
--- a/profiles/kentik_snmp/_general/host-resources-mib.yml
+++ b/profiles/kentik_snmp/_general/host-resources-mib.yml
@@ -36,16 +36,16 @@ metrics:
           OID: 1.3.6.1.2.1.25.2.3.1.2
           name: hrStorageType
           enum: 
-            Other: 1
-            Ram: 2
-            VirtualMemory: 3
-            FixedDisk: 4
-            RemovableDisk: 5
-            FloppyDisk: 6
-            CompactDisc: 7
-            RamDisk: 8
-            FlashMemory: 9
-            NetworkDisk: 10
+            Other: .1.3.6.1.2.1.25.2.1.1
+            Ram: .1.3.6.1.2.1.25.2.1.2
+            VirtualMemory: .1.3.6.1.2.1.25.2.1.3
+            FixedDisk: .1.3.6.1.2.1.25.2.1.4
+            RemovableDisk: .1.3.6.1.2.1.25.2.1.5
+            FloppyDisk: .1.3.6.1.2.1.25.2.1.6
+            CompactDisc: .1.3.6.1.2.1.25.2.1.7
+            RamDisk: .1.3.6.1.2.1.25.2.1.8
+            FlashMemory: .1.3.6.1.2.1.25.2.1.9
+            NetworkDisk: .1.3.6.1.2.1.25.2.1.10
             
   - MIB: HOST-RESOURCES-MIB
     table:

--- a/profiles/kentik_snmp/_general/host-resources-mib.yml
+++ b/profiles/kentik_snmp/_general/host-resources-mib.yml
@@ -36,16 +36,16 @@ metrics:
           OID: 1.3.6.1.2.1.25.2.3.1.2
           name: hrStorageType
           enum: 
-            Other: .1.3.6.1.2.1.25.2.1.1
-            Ram: .1.3.6.1.2.1.25.2.1.2
-            VirtualMemory: .1.3.6.1.2.1.25.2.1.3
-            FixedDisk: .1.3.6.1.2.1.25.2.1.4
-            RemovableDisk: .1.3.6.1.2.1.25.2.1.5
-            FloppyDisk: .1.3.6.1.2.1.25.2.1.6
-            CompactDisc: .1.3.6.1.2.1.25.2.1.7
-            RamDisk: .1.3.6.1.2.1.25.2.1.8
-            FlashMemory: .1.3.6.1.2.1.25.2.1.9
-            NetworkDisk: .1.3.6.1.2.1.25.2.1.10
+            Other: '.1.3.6.1.2.1.25.2.1.1'
+            Ram: '.1.3.6.1.2.1.25.2.1.2'
+            VirtualMemory: '.1.3.6.1.2.1.25.2.1.3'
+            FixedDisk: '.1.3.6.1.2.1.25.2.1.4'
+            RemovableDisk: '.1.3.6.1.2.1.25.2.1.5'
+            FloppyDisk: '.1.3.6.1.2.1.25.2.1.6'
+            CompactDisc: '.1.3.6.1.2.1.25.2.1.7'
+            RamDisk: '.1.3.6.1.2.1.25.2.1.8'
+            FlashMemory: '.1.3.6.1.2.1.25.2.1.9'
+            NetworkDisk: '.1.3.6.1.2.1.25.2.1.10'
             
   - MIB: HOST-RESOURCES-MIB
     table:


### PR DESCRIPTION
This enum is not working, we get a full OID back instead of a simple enum.  This may be a workable fix

Example walk data
```
.1.3.6.1.2.1.25.2.3.1.2.1 = OID: .1.3.6.1.2.1.25.2.1.2
.1.3.6.1.2.1.25.2.3.1.2.2 = OID: .1.3.6.1.2.1.25.2.1.2
.1.3.6.1.2.1.25.2.3.1.2.3 = OID: .1.3.6.1.2.1.25.2.1.3
.1.3.6.1.2.1.25.2.3.1.2.6 = OID: .1.3.6.1.2.1.25.2.1.1
.1.3.6.1.2.1.25.2.3.1.2.7 = OID: .1.3.6.1.2.1.25.2.1.1
.1.3.6.1.2.1.25.2.3.1.2.8 = OID: .1.3.6.1.2.1.25.2.1.1
.1.3.6.1.2.1.25.2.3.1.2.9 = OID: .1.3.6.1.2.1.25.2.1.1
.1.3.6.1.2.1.25.2.3.1.2.10 = OID: .1.3.6.1.2.1.25.2.1.3
.1.3.6.1.2.1.25.2.3.1.2.11 = OID: .1.3.6.1.2.1.25.2.1.1
.1.3.6.1.2.1.25.2.3.1.2.31 = OID: .1.3.6.1.2.1.25.2.1.4
.1.3.6.1.2.1.25.2.3.1.2.32 = OID: .1.3.6.1.2.1.25.2.1.4
.1.3.6.1.2.1.25.2.3.1.2.33 = OID: .1.3.6.1.2.1.25.2.1.4
.1.3.6.1.2.1.25.2.3.1.2.34 = OID: .1.3.6.1.2.1.25.2.1.4
.1.3.6.1.2.1.25.2.3.1.2.35 = OID: .1.3.6.1.2.1.25.2.1.4
.1.3.6.1.2.1.25.2.3.1.2.36 = OID: .1.3.6.1.2.1.25.2.1.10
.1.3.6.1.2.1.25.2.3.1.2.37 = OID: .1.3.6.1.2.1.25.2.1.4
.1.3.6.1.2.1.25.2.3.1.2.38 = OID: .1.3.6.1.2.1.25.2.1.4
```