### PR TITLE
Adding Cisco ISE Device Profile

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-ise.yml
+++ b/profiles/kentik_snmp/cisco/cisco-ise.yml
@@ -1,0 +1,37 @@
+# Cisco ISE Devices use standard SNMP MIBs
+# https://www.cisco.com/c/en/us/td/docs/security/ise/2-4/admin_guide/b_ISE_admin_guide_24/m_monitoring_and_troubleshooting.html
+---
+extends:
+  - host-resources-mib.yml
+  - if-mib.yml
+  - system-mib.yml
+  - ucd-mib.yml
+
+provider: kentik-cisco-ise
+
+sysobjectid:
+  - 1.3.6.1.4.1.9.1.2785    # Cisco SNS 3615 K9
+
+metrics:
+  # Memory Utilization
+  # Polled at 60s to support anomaly detection
+  - MIB: HOST-RESOURCES-MIB
+    symbol:
+      name: hrStorageSizeRAM
+      OID: 1.3.6.1.2.1.25.2.3.1.5.1
+      poll_time_sec: 60
+      tag: MemoryTotal
+  - MIB: HOST-RESOURCES-MIB
+    symbol:
+      name: hrStorageUsedRAM
+      OID: 1.3.6.1.2.1.25.2.3.1.6.1
+      poll_time_sec: 60
+      tag: MemoryUsed
+  # CPU Utilization
+  # Polled at 60s to support anomaly detection
+  - MIB: HOST-RESOURCES-MIB
+    symbol:
+      name: hrProcessorLoadCombined
+      OID: 1.3.6.1.2.1.25.3.3.1.2.196608
+      poll_time_sec: 60
+      tag: CPU

--- a/profiles/kentik_snmp/cisco/cisco-ise.yml
+++ b/profiles/kentik_snmp/cisco/cisco-ise.yml
@@ -7,7 +7,7 @@ extends:
   - system-mib.yml
   - ucd-mib.yml
 
-provider: kentik-cisco-ise
+provider: kentik-appliance
 
 sysobjectid:
   - 1.3.6.1.4.1.9.1.2785    # Cisco SNS 3615 K9


### PR DESCRIPTION
Adds Cisco ISE Profile, per documentation ISE devices do not have specific MIBs and [using the HOST-RESOURCES-MIB is suggested](https://www.cisco.com/c/en/us/td/docs/security/ise/2-4/admin_guide/b_ISE_admin_guide_24/m_monitoring_and_troubleshooting.html).