### PR TITLE
Fixing 2 cases where a sysoid is in 2 profiles

### DIFF
--- a/profiles/kentik_snmp/aruba/aruba-switch.yml
+++ b/profiles/kentik_snmp/aruba/aruba-switch.yml
@@ -169,7 +169,6 @@ sysobjectid:
   - 1.3.6.1.4.1.11.2.3.7.11.182.19    # JL355A/2540
   - 1.3.6.1.4.1.11.2.3.7.11.182.20    # JL356A/2540
   - 1.3.6.1.4.1.11.2.3.7.11.182.21    # JL357A/2540
-  - 1.3.6.1.4.1.47196.4.1.1.1.103     # JL661A/6300M
 
 metrics:
   - MIB: STATISTICS-MIB
@@ -200,13 +199,13 @@ metrics:
         name: pethMainPsePower
       - OID: 1.3.6.1.2.1.105.1.3.1.1.3
         name: pethMainOperStatus
-        enum: 
+        enum:
           on: 1
           off: 2
           faulty: 3
       - OID: 1.3.6.1.2.1.105.1.3.1.1.4
         name: pethMainPseConsumptionPower
-        
+
     metric_tags:
       - column:
           OID: 1.3.6.1.2.1.105.1.3.1.1.1

--- a/profiles/kentik_snmp/cyberpower/cyberpower-pdu.yml
+++ b/profiles/kentik_snmp/cyberpower/cyberpower-pdu.yml
@@ -5,7 +5,7 @@ extends:
 
 provider: kentik-pdu
 
-sysobjectid: 1.3.6.1.4.1.318.1.3.4.*
+sysobjectid: 1.3.6.1.4.1.318.1.3.4.cyberpower
 
 metrics:
   - MIB: CPS-MIB
@@ -71,7 +71,7 @@ metrics:
       # Getting this OID will return the measured Outlet load for an Outlet Monitored Rack PDU in watts
       - OID: 1.3.6.1.4.1.3808.1.1.3.3.5.1.1.8
         name: ePDUOutletStatusActivePower
-      # 
+      #
       - OID: 1.3.6.1.4.1.3808.1.1.3.3.5.1.1.9
         name: ePDUOutletStatusAlarm
         enum:
@@ -215,7 +215,7 @@ metrics:
           name: ePDU2DeviceStatusName
       # Get this oid shows the role the PDU played on Daisy Chain Group. The PDU as a Host can access whole ePDU2 content, and the PDU be standalong or a Slave can access itself instead.
       - column:
-          OID: 
+          OID:
           name: ePDU2DeviceStatusRoleType	1.3.6.1.4.1.3808.1.1.6.3.4.1.17
           enum:
             standalone: 1


### PR DESCRIPTION
I saw that 2 sysoids were causing errors because they are duplicated across profiles. I'm not sure about the fix for cyberpower. 