### PR TITLE
Set the walk_full_table option for a broken MIB

### DIFF
--- a/profiles/kentik_snmp/elemental/elemental-device.yml
+++ b/profiles/kentik_snmp/elemental/elemental-device.yml
@@ -52,6 +52,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.37086.5.1.1
       name: eventTable
+    walk_full_table: true
     symbols:
       - name: eventRunning
         OID: 1.3.6.1.4.1.37086.5.1.1.1.3


### PR DESCRIPTION
This is connected to https://github.com/kentik/ktranslate/pull/576