### PR TITLE
Reclassify exagrid as generic SNMP appliance

### DIFF
--- a/profiles/kentik_snmp/exagrid/exagrid.yml
+++ b/profiles/kentik_snmp/exagrid/exagrid.yml
@@ -5,7 +5,7 @@ extends:
   - if-mib.yml
   - host-resources-mib.yml
 
-provider: kentik-backup-appliance
+provider: kentik-appliance
 
 sysobjectid:
   - 1.3.6.1.4.1.14941.3.* # exagrid appliances


### PR DESCRIPTION
Hey @i3149. This PR is mostly to make it easier for New Relic to classify this type of entity in our platform. It looks like there's only one other device that uses that backup-appliance provider.

I figure there's a small risk that this PR could cause a regression if somebody's relying on that specific provider value so I wanted to check: Is this kind of reclassification generally ok or something we want to avoid?