### PR TITLE
Fix cyberpower profiles

### DIFF
--- a/profiles/kentik_snmp/cyberpower/cyberpower-pdu.yml
+++ b/profiles/kentik_snmp/cyberpower/cyberpower-pdu.yml
@@ -5,7 +5,11 @@ extends:
 
 provider: kentik-pdu
 
-sysobjectid: 1.3.6.1.4.1.3808.1.1.*
+sysobjectid:
+  - 1.3.6.1.4.1.3808.1.1.3      # Cyberpower ePDU
+  - 1.3.6.1.4.1.3808.1.1.3.*    # Cyberpower ePDU
+  - 1.3.6.1.4.1.3808.1.1.6      # Cyberpower ePDU2
+  - 1.3.6.1.4.1.3808.1.1.6.*    # Cyberpower ePDU2
 
 metrics:
   - MIB: CPS-MIB

--- a/profiles/kentik_snmp/cyberpower/cyberpower-ups.yml
+++ b/profiles/kentik_snmp/cyberpower/cyberpower-ups.yml
@@ -6,96 +6,76 @@ extends:
 provider: kentik-ups
 
 sysobjectid:
-  - 1.3.6.1.4.1.3808.1.1.1
-  - 1.3.6.1.4.1.3808*
+  - 1.3.6.1.4.1.3808.1.1.1      # Cyberpower UPS
+  - 1.3.6.1.4.1.3808.1.1.1.*    # Cyberpower UPS
 
 metrics:
   - MIB: CPS-MIB_UPS
-    symbol:
-      OID: 1.3.6.1.4.1.3808.1.1.1.1
-      name: upsIdent
-  - MIB: CPS-MIB_UPS
-    symbol:
-      OID: 1.3.6.1.4.1.3808.1.1.1.2.2.4.0
-      name: upsAdvBatteryRunTimeRemaining
-  - MIB: CPS-MIB_UPS
-    symbol:
-      OID: 1.3.6.1.4.1.3808.1.1.1.2.2.3
-      name: upsAdvanceBatteryTemperature
-  - MIB: CPS-MIB_UPS
-    symbol:
-      OID: 1.3.6.1.4.1.3808.1.1.1.2.2.1
-      name: upsAdvanceBatteryCapacity
-  - MIB: CPS-MIB_UPS
-    symbol:
-      OID: 1.3.6.1.4.1.3808.1.1.1.2.1.2
-      name: upsBaseBatteryTimeOnBattery
-  - MIB: CPS-MIB_UPS
-    symbol:
-      OID: 1.3.6.1.4.1.3808.1.1.1.2.1.1
-      name: upsBaseBatteryStatus
-      enum:
-        unknown: 1
-        batteryNormal: 2
-        batteryLow: 3
-  - MIB: CPS-MIB_UPS
-    symbol:
-      OID: 1.3.6.1.4.1.3808.1.1.1.2.2.5
-      name: upsAdvanceBatteryReplaceIndicator
-      enum:
-        noBatteryNeedsReplacing: 1
-        batteryNeedsReplacing: 2
-  - MIB: CPS-MIB_UPS
-    symbol:
-      OID: 1.3.6.1.4.1.3808.1.1.1.3.2.5
-      name: upsAdvanceInputLineFailCause
-      enum:
-        noTransfer: 1
-        highLineVoltage: 2
-        brownout: 3
-        selfTest: 4
-  - MIB: CPS-MIB_UPS
-    symbol:
-      OID: 1.3.6.1.4.1.3808.1.1.1.3.2.1
-      name: upsAdvanceInputLineVoltage
-  - MIB: CPS-MIB_UPS
-    symbol:
-      OID: 1.3.6.1.4.1.3808.1.1.1.4.2.1
-      name: upsAdvanceOutputVoltage
-  - MIB: CPS-MIB_UPS
-    symbol:
-      OID:     1.3.6.1.4.1.3808.1.1.1.4.2.3
-      name: upsAdvanceOutputLoad
-  - MIB: CPS-MIB_UPS
-    symbol:
-      OID: 1.3.6.1.4.1.3808.1.1.1.3.1.1
-      name: upsBaseInputPhase
-  - MIB: CPS-MIB_UPS
-    symbol:
-      OID: 1.3.6.1.4.1.3808.1.1.1.4.1.2
-      name: upsBaseOutputPhase
-  - MIB: CPS-MIB_UPS
-    symbol:
-      OID: 1.3.6.1.4.1.3808.1.1.1.7.2.3
-      name: upsAdvTestDiagnosticsResults
-      enum:
-        ok: 1
-        failed: 2
-        invalidTest: 3
-        testInProgress: 4
+    symbols:
+      - OID: 1.3.6.1.4.1.3808.1.1.1.2.1.1.0
+        name: upsBaseBatteryStatus
+        enum:
+          unknown: 1
+          batteryNormal: 2
+          batteryLow: 3
+      - OID: 1.3.6.1.4.1.3808.1.1.1.2.1.2.0
+        name: upsBaseBatteryTimeOnBattery
+
+      - OID: 1.3.6.1.4.1.3808.1.1.1.2.2.1.0
+        name: upsAdvanceBatteryCapacity
+      - OID: 1.3.6.1.4.1.3808.1.1.1.2.2.3.0
+        name: upsAdvanceBatteryTemperature
+      - OID: 1.3.6.1.4.1.3808.1.1.1.2.2.4.0
+        name: upsAdvanceBatteryRunTimeRemaining
+      - OID: 1.3.6.1.4.1.3808.1.1.1.2.2.5.0
+        name: upsAdvanceBatteryReplaceIndicator
+        enum:
+          noBatteryNeedsReplacing: 1
+          batteryNeedsReplacing: 2
+
+      - OID: 1.3.6.1.4.1.3808.1.1.1.3.1.1.0
+        name: upsBaseInputPhase
+
+      - OID: 1.3.6.1.4.1.3808.1.1.1.3.2.1.0
+        name: upsAdvanceInputLineVoltage
+      - OID: 1.3.6.1.4.1.3808.1.1.1.3.2.5.0
+        name: upsAdvanceInputLineFailCause
+        enum:
+          noTransfer: 1
+          highLineVoltage: 2
+          brownout: 3
+          selfTest: 4
+      - OID: 1.3.6.1.4.1.3808.1.1.1.3.2.6.0
+        name: upsAdvanceInputStatus
+
+      - OID: 1.3.6.1.4.1.3808.1.1.1.4.2.1.0
+        name: upsAdvanceOutputVoltage
+      - OID: 1.3.6.1.4.1.3808.1.1.1.4.2.3.0
+        name: upsAdvanceOutputLoad
+
+      - OID: 1.3.6.1.4.1.3808.1.1.1.4.1.1.0
+        name: upsBaseOutputStatus
+      - OID: 1.3.6.1.4.1.3808.1.1.1.4.1.2.0
+        name: upsBaseOutputPhase
+
+      - OID: 1.3.6.1.4.1.3808.1.1.1.7.2.3.0
+        name: upsAdvTestDiagnosticsResults
+        enum:
+          ok: 1
+          failed: 2
+          invalidTest: 3
+          testInProgress: 4
+
   - MIB: CPS-MIB_UPS
     table:
-      OID: 1.3.6.1.4.1.3808.1.1.1.3.2.6
-      name: upsAdvanceInputStatus
-  - MIB: CPS-MIB_UPS
-    table:
-      OID: 1.3.6.1.4.1.3808.1.1.1.4.1.1
-      name: upsBaseOutputStatus
-  - MIB: CPS-MIB_UPS
-    table:
-      OID: 1.3.6.1.4.1.3808.1.1.1.5.1.2.1.2
-      name: deviceName
-    #The name of the equipment plugged into the UPS.
+      OID: 1.3.6.1.4.1.3808.1.1.1.5.1.2
+      name: upsBaseConfigDeviceTable
+    symbols:
+      # The name of the equipment plugged into the UPS.
+      - OID: 1.3.6.1.4.1.3808.1.1.1.5.1.2.1.2
+        name: deviceName
+        conversion: to_one
+
 metric_tags:
   - column:
       OID: 1.3.6.1.4.1.3808.1.1.1.1.1.1


### PR DESCRIPTION
Noticed that these profiles were throwing errors relating to improper yaml and had overlapping sysoids

