### PR TITLE
Adding a script to record isilon cpu

### DIFF
--- a/profiles/kentik_snmp/isilon/isilon.yml
+++ b/profiles/kentik_snmp/isilon/isilon.yml
@@ -24,6 +24,16 @@ metrics:
         column:
           OID: 1.3.6.1.4.1.12124.2.53.1.1
           name: fanNumber
+  - MIB: ISILON-MIB2
+    symbol:
+      OID: 1.3.6.1.4.1.12124.1.2.3.5
+      name: clusterCPUIdlePct
+      script: |
+        def main(n):
+          cpuim = n["clusterCPUIdlePct"]
+          if cpuim <= 1000:
+            n["CPU"] = (1000 - cpuim) * 0.1
+          return None
   - MIB: ISILON-MIB
     symbol:
       OID: 1.3.6.1.4.1.12124.1.1.2.0

--- a/profiles/kentik_snmp/isilon/isilon.yml
+++ b/profiles/kentik_snmp/isilon/isilon.yml
@@ -24,7 +24,7 @@ metrics:
         column:
           OID: 1.3.6.1.4.1.12124.2.53.1.1
           name: fanNumber
-  - MIB: ISILON-MIB2
+  - MIB: ISILON-MIB
     symbol:
       OID: 1.3.6.1.4.1.12124.1.2.3.5
       name: clusterCPUIdlePct


### PR DESCRIPTION
This works for https://github.com/kentik/ktranslate/issues/615. 

Rather than adding go code, how about using python to calculate CPU on the fly? 

In my testing, this will correctly return CPU idle as a float. 