### PR TITLE
Update cisco-all-devices.yml

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-all-devices.yml
+++ b/profiles/kentik_snmp/cisco/cisco-all-devices.yml
@@ -386,6 +386,9 @@ metrics:
       - name: cefcModuleStateChangeReasonDescr
         OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.7
         conversion: to_one
+      - name: cefcModuleUpTime
+        OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.8
+
     metric_tags:
       # A textual description of physical entity.
       - tag: entity_description


### PR DESCRIPTION
Added uptime OID for module
Device SysOID- 1.3.6.1.4.1.9.12.3.1.3.1648
Attached screenshot of snmp output for reference
![Screenshot_1](https://github.com/kentik/snmp-profiles/assets/69621334/e1bb5f8e-aedb-48c5-bf22-ab9091c39c80)
@thezackm can you please review and approve. Thanks