### PR TITLE
chore: remove dupe sysoid from isilon

### DIFF
--- a/profiles/kentik_snmp/isilon/isilon.yml
+++ b/profiles/kentik_snmp/isilon/isilon.yml
@@ -8,7 +8,6 @@ provider: kentik-nas
 
 sysobjectid: 
   - 1.3.6.1.4.1.12124.*
-  - 1.3.6.1.4.1.12325.*
 
 metrics:
   # CPU and Memory


### PR DESCRIPTION
Isilon has a fix to stop using this sysOID that is for pfSense. 