### PR TITLE
Create APC ATS Profile

### DIFF
--- a/profiles/kentik_snmp/apc/apc_ats.yml
+++ b/profiles/kentik_snmp/apc/apc_ats.yml
@@ -119,33 +119,35 @@ metrics:
       OID: 1.3.6.1.4.1.318.1.1.8.5.3.2
       name: atsInputTable
     symbols:
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.2
-        name: atsNumInputPhases
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.3
-        name: atsInputVoltageOrientation
-        enum:
-          unknown: 1
-          singlePhase: 2
-          splitPhase: 3
-          threePhaseToNeutral: 4
-          threePhaseToPhase: 5
       - OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.4
         name: atsInputFrequency
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.5
-        name: atsInputType
-        enum:
-          unknown: 1
-          main: 2
-          bypass: 3
     metric_tags:
-      - tag: input_index
-        column:
-          OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.1
-          name: atsInputTableIndex
       - tag: input_name
         column:
           OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.6
           name: atsInputName
+      - tag: input_num_phases
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.2
+          name: atsNumInputPhases
+      - tag: input_voltage_orientation
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.3
+          name: atsInputVoltageOrientation
+          enum:
+            unknown: 1
+            singlePhase: 2
+            splitPhase: 3
+            threePhaseToNeutral: 4
+            threePhaseToPhase: 5
+      - tag: input_type
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.5
+          name: atsInputType
+          enum:
+            unknown: 1
+            main: 2
+            bypass: 3
   - MIB: PowerNet-MIB_ATS
     table:
       OID: 1.3.6.1.4.1.318.1.1.8.5.3.3
@@ -153,54 +155,62 @@ metrics:
     symbols:
       - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.3
         name: atsInputVoltage
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.4
-        name: atsInputMaxVoltage
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.5
-        name: atsInputMinVoltage
       - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.6
         name: atsInputCurrent
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.7
-        name: atsInputMaxCurrent
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.8
-        name: atsInputMinCurrent
       - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.9
         name: atsInputPower
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.10
-        name: atsInputMaxPower
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.11
-        name: atsInputMinPower
     metric_tags:
-      - tag: input_phase_index
-        column:
-          OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.1
-          name: atsInputPhaseTableIndex
       - tag: input_phase_number
         column:
           OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.2
           name: atsInputPhaseIndex
+      - tag: input_max_voltage
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.4
+          name: atsInputMaxVoltage
+      - tag: input_min_voltage
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.5
+          name: atsInputMinVoltage
+      - tag: input_max_current
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.7
+          name: atsInputMaxCurrent
+      - tag: input_min_current
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.8
+          name: atsInputMinCurrent
+      - tag: input_max_power
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.10
+          name: atsInputMaxPower
+      - tag: input_min_power
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.11
+          name: atsInputMinPower
 
   - MIB: PowerNet-MIB_ATS
     table:
       OID: 1.3.6.1.4.1.318.1.1.8.5.4.2
       name: atsOutputTable
     symbols:
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.2.1.2
-        name: atsNumOutputPhases
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.2.1.3
-        name: atsOuputVoltageOrientation
-        enum:
-          unknown: 1
-          singlePhase: 2
-          splitPhase: 3
-          threePhaseToNeutral: 4
-          threePhaseToPhase: 5
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.2.1.4
         name: atsOutputFrequency
     metric_tags:
-      - tag: output_index
+      - tag: output_num_phases
         column:
-          OID: 1.3.6.1.4.1.318.1.1.8.5.4.2.1.1
-          name: atsOutputTableIndex
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.2.1.2
+          name: atsNumOutputPhases
+      - tag: output_voltage_orientation
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.2.1.3
+          name: atsOuputVoltageOrientation
+          enum:
+            unknown: 1
+            singlePhase: 2
+            splitPhase: 3
+            threePhaseToNeutral: 4
+            threePhaseToPhase: 5
   - MIB: PowerNet-MIB_ATS
     table:
       OID: 1.3.6.1.4.1.318.1.1.8.5.4.3
@@ -210,34 +220,14 @@ metrics:
         name: atsOutputVoltage
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.4
         name: atsOutputCurrent
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.5
-        name: atsOutputMaxCurrent
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.6
-        name: atsOutputMinCurrent
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.7
         name: atsOutputLoad
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.8
-        name: atsOutputMaxLoad
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.9
-        name: atsOutputMinLoad
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.10
         name: atsOutputPercentLoad
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.11
-        name: atsOutputMaxPercentLoad
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.12
-        name: atsOutputMinPercentLoad
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.13
         name: atsOutputPower
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.14
-        name: atsOutputMaxPower
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.15
-        name: atsOutputMinPower
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.16
         name: atsOutputPercentPower
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.17
-        name: atsOutputMaxPercentPower
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.18
-        name: atsOutputMinPercentPower
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.19
         name: atsOutputPhaseState
         enum:
@@ -246,31 +236,55 @@ metrics:
           nearoverload: 3
           overload: 4
     metric_tags:
-      - tag: output_phase_index
-        column:
-          OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.1
-          name: atsOutputPhaseTableIndex
       - tag: output_phase_number
         column:
           OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.2
           name: atsOutputPhaseIndex
+      - tag: output_phase_max_current
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.5
+          name: atsOutputMaxCurrent
+      - tag: output_phase_min_current
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.6
+          name: atsOutputMinCurrent
+      - tag: output_phase_max_load
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.8
+          name: atsOutputMaxLoad
+      - tag: output_phase_min_load
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.9
+          name: atsOutputMinLoad
+      - tag: output_phase_max_percent_load
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.11
+          name: atsOutputMaxPercentLoad
+      - tag: output_phase_min_percent_load
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.12
+          name: atsOutputMinPercentLoad
+      - tag: output_phase_max_power
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.14
+          name: atsOutputMaxPower
+      - tag: output_phase_min_power
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.15
+          name: atsOutputMinPower
+      - tag: output_phase_max_percent_power
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.17
+          name: atsOutputMaxPercentPower
+      - tag: output_phase_min_percent_power
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.18
+          name: atsOutputMinPercentPower
   - MIB: PowerNet-MIB_ATS
     table:
       OID: 1.3.6.1.4.1.318.1.1.8.5.4.5
       name: atsOutputBankTable
     symbols:
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.2
-        name: atsOutputPhase
-        enum:
-          phase1: 1
-          phase2: 2
-          phase3: 3
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.3
-        name: atsOutputBank
-        enum:
-          total: 1
-          bank1: 2
-          bank2: 3
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.4
         name: atsOutputBankCurrent
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.5
@@ -282,39 +296,71 @@ metrics:
           overload: 4
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.6
         name: atsOutputBankOutputVoltage
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.7
-        name: atsOutputBankMaxCurrent
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.8
-        name: atsOutputBankMinCurrent
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.9
         name: atsOutputBankLoad
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.10
-        name: atsOutputBankMaxLoad
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.11
-        name: atsOutputBankMinLoad
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.12
         name: atsOutputBankPercentLoad
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.13
-        name: atsOutputBankMaxPercentLoad
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.14
-        name: atsOutputBankMinPercentLoad
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.15
         name: atsOutputBankPower
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.16
-        name: atsOutputBankMaxPower
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.17
-        name: atsOutputBankMinPower
       - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.18
         name: atsOutputBankPercentPower
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.19
-        name: atsOutputBankMaxPercentPower
-      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.20
-        name: atsOutputBankMinPercentPower
     metric_tags:
-      - tag: output_bank_table_index
+      - tag: output_bank_phase
         column:
-          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.1
-          name: atsOutputBankTableIndex
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.2
+          name: atsOutputPhase
+          enum:
+            phase1: 1
+            phase2: 2
+            phase3: 3
+      - tag: output_bank_num
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.3
+          name: atsOutputBank
+          enum:
+            total: 1
+            bank1: 2
+            bank2: 3
+      - tag: output_bank_max_current
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.7
+          name: atsOutputBankMaxCurrent
+      - tag: output_bank_min_current
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.8
+          name: atsOutputBankMinCurrent
+      - tag: output_bank_max_load
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.10
+          name: atsOutputBankMaxLoad
+      - tag: output_bank_min_load
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.11
+          name: atsOutputBankMinLoad
+      - tag: output_bank_max_percent_load
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.13
+          name: atsOutputBankMaxPercentLoad
+      - tag: output_bank_min_percent_load
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.14
+          name: atsOutputBankMinPercentLoad
+      - tag: output_bank_max_power
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.16
+          name: atsOutputBankMaxPower
+      - tag: output_bank_min_power
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.17
+          name: atsOutputBankMinPower
+      - tag: output_bank_max_percent_power
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.19
+          name: atsOutputBankMaxPercentPower
+      - tag: output_bank_min_percent_power
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.20
+          name: atsOutputBankMinPercentPower
 metric_tags:
   - column:
       OID: 1.3.6.1.4.1.318.1.1.8.1.1

--- a/profiles/kentik_snmp/apc/apc_ats.yml
+++ b/profiles/kentik_snmp/apc/apc_ats.yml
@@ -1,0 +1,346 @@
+# http://oid-info.com/get/1.3.6.1.4.1.318.1.1.8
+---
+extends:
+  - system-mib.yml
+
+provider: kentik-ats
+
+sysobjectid: 1.3.6.1.4.1.318.1.3.11   # APC Automatic Transfer Switch
+
+metrics:
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.2
+      name: atsStatusSelectedSource
+      enum:
+        sourceA: 1
+        sourceB: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.3
+      name: atsStatusRedundancyState
+      enum:
+        atsRedundancyLost: 1
+        atsFullyRedundant: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.4
+      name: atsStatusOverCurrentState
+      enum:
+        atsOverCurrent: 1
+        atsCurrentOK: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.5
+      name: atsStatus5VPowerSupply
+      enum:
+        atsPowerSupplyFailure: 1
+        atsPowerSupplyOK: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.6
+      name: atsStatus24VPowerSupply
+      enum:
+        atsPowerSupplyFailure: 1
+        atsPowerSupplyOK: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.7
+      name: atsStatus24VSourceBPowerSupply
+      enum:
+        atsPowerSupplyFailure: 1
+        atsPowerSupplyOK: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.8
+      name: atsStatusPlus12VPowerSupply
+      enum:
+        atsPowerSupplyFailure: 1
+        atsPowerSupplyOK: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.9
+      name: atsStatusMinus12VPowerSupply
+      enum:
+        atsPowerSupplyFailure: 1
+        atsPowerSupplyOK: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.10
+      name: atsStatusSwitchStatus
+      enum:
+        fail: 1
+        ok: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.11
+      name: atsStatusFrontPanel
+      enum:
+        locked: 1
+        unlocked: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.12
+      name: atsStatusSourceAStatus
+      enum:
+        fail: 1
+        ok: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.13
+      name: atsStatusSourceBStatus
+      enum:
+        fail: 1
+        ok: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.14
+      name: atsStatusPhaseSyncStatus
+      enum:
+        inSync: 1
+        outOfSync: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.15
+      name: atsStatusVoltageOutStatus
+      enum:
+        fail: 1
+        ok: 2
+  - MIB: PowerNet-MIB_ATS
+    symbol:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.1.16
+      name: atsStatusHardwareStatus
+      enum:
+        fail: 1
+        ok: 2
+
+  - MIB: PowerNet-MIB_ATS
+    table:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.3.2
+      name: atsInputTable
+    symbols:
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.2
+        name: atsNumInputPhases
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.3
+        name: atsInputVoltageOrientation
+        enum:
+          unknown: 1
+          singlePhase: 2
+          splitPhase: 3
+          threePhaseToNeutral: 4
+          threePhaseToPhase: 5
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.4
+        name: atsInputFrequency
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.5
+        name: atsInputType
+        enum:
+          unknown: 1
+          main: 2
+          bypass: 3
+    metric_tags:
+      - tag: input_index
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.1
+          name: atsInputTableIndex
+      - tag: input_name
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.3.2.1.6
+          name: atsInputName
+  - MIB: PowerNet-MIB_ATS
+    table:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.3.3
+      name: atsInputPhaseTable
+    symbols:
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.3
+        name: atsInputVoltage
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.4
+        name: atsInputMaxVoltage
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.5
+        name: atsInputMinVoltage
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.6
+        name: atsInputCurrent
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.7
+        name: atsInputMaxCurrent
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.8
+        name: atsInputMinCurrent
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.9
+        name: atsInputPower
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.10
+        name: atsInputMaxPower
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.11
+        name: atsInputMinPower
+    metric_tags:
+      - tag: input_phase_index
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.1
+          name: atsInputPhaseTableIndex
+      - tag: input_phase_number
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.3.3.1.2
+          name: atsInputPhaseIndex
+
+  - MIB: PowerNet-MIB_ATS
+    table:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.4.2
+      name: atsOutputTable
+    symbols:
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.2.1.2
+        name: atsNumOutputPhases
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.2.1.3
+        name: atsOuputVoltageOrientation
+        enum:
+          unknown: 1
+          singlePhase: 2
+          splitPhase: 3
+          threePhaseToNeutral: 4
+          threePhaseToPhase: 5
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.2.1.4
+        name: atsOutputFrequency
+    metric_tags:
+      - tag: output_index
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.2.1.1
+          name: atsOutputTableIndex
+  - MIB: PowerNet-MIB_ATS
+    table:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.4.3
+      name: atsOutputPhaseTable
+    symbols:
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.3
+        name: atsOutputVoltage
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.4
+        name: atsOutputCurrent
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.5
+        name: atsOutputMaxCurrent
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.6
+        name: atsOutputMinCurrent
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.7
+        name: atsOutputLoad
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.8
+        name: atsOutputMaxLoad
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.9
+        name: atsOutputMinLoad
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.10
+        name: atsOutputPercentLoad
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.11
+        name: atsOutputMaxPercentLoad
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.12
+        name: atsOutputMinPercentLoad
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.13
+        name: atsOutputPower
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.14
+        name: atsOutputMaxPower
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.15
+        name: atsOutputMinPower
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.16
+        name: atsOutputPercentPower
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.17
+        name: atsOutputMaxPercentPower
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.18
+        name: atsOutputMinPercentPower
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.19
+        name: atsOutputPhaseState
+        enum:
+          normal: 1
+          lowload: 2
+          nearoverload: 3
+          overload: 4
+    metric_tags:
+      - tag: output_phase_index
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.1
+          name: atsOutputPhaseTableIndex
+      - tag: output_phase_number
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.3.1.2
+          name: atsOutputPhaseIndex
+  - MIB: PowerNet-MIB_ATS
+    table:
+      OID: 1.3.6.1.4.1.318.1.1.8.5.4.5
+      name: atsOutputBankTable
+    symbols:
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.2
+        name: atsOutputPhase
+        enum:
+          phase1: 1
+          phase2: 2
+          phase3: 3
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.3
+        name: atsOutputBank
+        enum:
+          total: 1
+          bank1: 2
+          bank2: 3
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.4
+        name: atsOutputBankCurrent
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.5
+        name: atsOutputBankState
+        enum:
+          normal: 1
+          lowload: 2
+          nearoverload: 3
+          overload: 4
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.6
+        name: atsOutputBankOutputVoltage
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.7
+        name: atsOutputBankMaxCurrent
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.8
+        name: atsOutputBankMinCurrent
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.9
+        name: atsOutputBankLoad
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.10
+        name: atsOutputBankMaxLoad
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.11
+        name: atsOutputBankMinLoad
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.12
+        name: atsOutputBankPercentLoad
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.13
+        name: atsOutputBankMaxPercentLoad
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.14
+        name: atsOutputBankMinPercentLoad
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.15
+        name: atsOutputBankPower
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.16
+        name: atsOutputBankMaxPower
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.17
+        name: atsOutputBankMinPower
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.18
+        name: atsOutputBankPercentPower
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.19
+        name: atsOutputBankMaxPercentPower
+      - OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.20
+        name: atsOutputBankMinPercentPower
+    metric_tags:
+      - tag: output_bank_table_index
+        column:
+          OID: 1.3.6.1.4.1.318.1.1.8.5.4.5.1.1
+          name: atsOutputBankTableIndex
+metric_tags:
+  - column:
+      OID: 1.3.6.1.4.1.318.1.1.8.1.1
+      name: atsIdentHardwareRev
+    tag: hardware_revision
+  - column:
+      OID: 1.3.6.1.4.1.318.1.1.8.1.2
+      name: atsIdentFirmwareRev
+    tag: firmware_revision
+  - column:
+      OID: 1.3.6.1.4.1.318.1.1.8.1.5
+      name: atsIdentModelNumber
+    tag: model_number
+  - column:
+      OID: 1.3.6.1.4.1.318.1.1.8.1.6
+      name: atsIdentSerialNumber
+    tag: serial_number
+  - column:
+      OID: 1.3.6.1.4.1.318.1.1.8.1.9
+      name: atsIdentDeviceRating
+    tag: amps_rating  
+  - column:
+      OID: 1.3.6.1.4.1.318.1.1.8.1.7
+      name: atsIdentNominalLineVoltage
+    tag: nominal_line_voltage
+  - column:
+      OID: 1.3.6.1.4.1.318.1.1.8.1.8
+      name: atsIdentNominalLineVoltage
+    tag: nominal_line_frequency


### PR DESCRIPTION
Creates a profile for APC Automated Transfer Switches (tested on AP7752, which doesn't support some of the features in the MIB).

[snmpwalk_ats.txt](https://github.com/kentik/snmp-profiles/files/13572148/snmpwalk_ats.txt)
[POWERNET-MIB.mib.zip](https://github.com/kentik/snmp-profiles/files/13572157/POWERNET-MIB.mib.zip)
