### PR TITLE
fix: add proper enum to metric

### DIFF
--- a/profiles/kentik_snmp/a10_networks/a10-thunder.yml
+++ b/profiles/kentik_snmp/a10_networks/a10-thunder.yml
@@ -456,9 +456,11 @@ metrics:
       - name: axVirtualServerStatDisplayStatus
         OID: 1.3.6.1.4.1.22610.2.4.3.4.2.1.1.11
         enum:
-          up: 1
-          down: 2
-          disabled: 3
+          disabled: 0
+          allUp: 1
+          functionalUp: 2
+          partialUp: 3
+          stopped: 4
       # The total number of L7 requests if applicable
       - name: axVirtualServerStatTotalL7Reqs	
         OID: 1.3.6.1.4.1.22610.2.4.3.4.2.1.1.12


### PR DESCRIPTION
updating to add all enum options from [axVirtualServerStatDisplayStatus](https://www.circitor.fr/Mibs/Html/A/A10-AX-MIB.php#axVirtualServerStatDisplayStatus)