### PR TITLE
Making f5 traps work better

### DIFF
--- a/profiles/kentik_snmp/f5/traps.yml
+++ b/profiles/kentik_snmp/f5/traps.yml
@@ -85,10 +85,10 @@ traps:
         OID: 1.3.6.1.4.1.3375.2.4.1.1
         tag: message
       - name: bigipNotifyObjNode
-        OID: 1.3.6.1.4.1.3375.2.4.1.1
+        OID: 1.3.6.1.4.1.3375.2.4.1.2
         tag: node_name
       - name: bigipNotifyObjPort
-        OID: 1.3.6.1.4.1.3375.2.4.1.1
+        OID: 1.3.6.1.4.1.3375.2.4.1.3
         tag: service_port
   # A service is detected UP.
   - trap_name: bigipServiceUp
@@ -99,10 +99,10 @@ traps:
         OID: 1.3.6.1.4.1.3375.2.4.1.1
         tag: message
       - name: bigipNotifyObjNode
-        OID: 1.3.6.1.4.1.3375.2.4.1.1
+        OID: 1.3.6.1.4.1.3375.2.4.1.2
         tag: node_name
       - name: bigipNotifyObjPort
-        OID: 1.3.6.1.4.1.3375.2.4.1.1
+        OID: 1.3.6.1.4.1.3375.2.4.1.3
         tag: service_port
   # A node is detected DOWN.
   - trap_name: bigipNodeDown
@@ -113,7 +113,7 @@ traps:
         OID: 1.3.6.1.4.1.3375.2.4.1.1
         tag: message
       - name: bigipNotifyObjNode
-        OID: 1.3.6.1.4.1.3375.2.4.1.1
+        OID: 1.3.6.1.4.1.3375.2.4.1.2
         tag: node_name
   # A node is detected UP.
   - trap_name: bigipNodeUp
@@ -124,7 +124,7 @@ traps:
         OID: 1.3.6.1.4.1.3375.2.4.1.1
         tag: message
       - name: bigipNotifyObjNode
-        OID: 1.3.6.1.4.1.3375.2.4.1.1
+        OID: 1.3.6.1.4.1.3375.2.4.1.2
         tag: node_name
   # The system is going into standby mode.
   - trap_name: bigipStandby


### PR DESCRIPTION
This removes some duplicate oids in the f5 definition which I think was messing things up. Now inputs look like:

```json
[{"TrapName":"bigipServiceUp","src_addr":"192.168.0.200","instrumentation.provider":"kentik","provider":"kentik-trap-device","node_name":"/Common/XXX","service_port":"80","TrapOID":".1.3.6.1.4.1.3375.2.4.0.11","collector.name":"ktranslate","message":"Pool /Common/RC_CRM-b-_Pool member /Common/XXX:80 monitor status up. [ /Common/http: up, /Common/http_evo2_F5test: up ]  [ was down for 0hr:0min:8sec ]","device_name":"192.168.0.200","eventType":"KSnmpTrap","instrumentation.name":"netflow-events"}]
```