### PR TITLE
Update cisco-firepower.yml

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-firepower.yml
+++ b/profiles/kentik_snmp/cisco/cisco-firepower.yml
@@ -128,13 +128,18 @@ metrics:
         
  # FTD failover status
   - MIB: CISCO-UNIFIED-FIREWALL-MIB
+    table:
+      OID: 1.3.6.1.4.1.9.9.491.1.4.2.1
+      name: cufwFOGrpStatusTable
     symbols:
-      - name: cufwFOGroupIndex
-        OID: 1.3.6.1.4.1.9.9.491.1.4.2.1.1.1
       - name: cufwFOGrpLastFailoverAt
         OID: 1.3.6.1.4.1.9.9.491.1.4.2.1.1.2
+        conversion: to_one
       - name: cufwFOGrpHAstate
         OID: 1.3.6.1.4.1.9.9.491.1.4.2.1.1.3
+        enum:
+          Active: 0
+          Standby: 1
       - name: cufwFOGrpUpTime
         OID: 1.3.6.1.4.1.9.9.491.1.4.2.1.1.4
       - name: cufwFOGrpContextCount

--- a/profiles/kentik_snmp/cisco/cisco-firepower.yml
+++ b/profiles/kentik_snmp/cisco/cisco-firepower.yml
@@ -125,6 +125,20 @@ metrics:
         OID: 1.3.6.1.4.1.9.9.392.1.1.2.0
       - name: crasNumSetupFailInsufResources
         OID: 1.3.6.1.4.1.9.9.392.1.4.1.3.0
+        
+ # FTD failover status
+  - MIB: CISCO-UNIFIED-FIREWALL-MIB
+    symbols:
+      - name: cufwFOGroupIndex
+        OID: 1.3.6.1.4.1.9.9.491.1.4.2.1.1.1
+      - name: cufwFOGrpLastFailoverAt
+        OID: 1.3.6.1.4.1.9.9.491.1.4.2.1.1.2
+      - name: cufwFOGrpHAstate
+        OID: 1.3.6.1.4.1.9.9.491.1.4.2.1.1.3
+      - name: cufwFOGrpUpTime
+        OID: 1.3.6.1.4.1.9.9.491.1.4.2.1.1.4
+      - name: cufwFOGrpContextCount
+        OID: 1.3.6.1.4.1.9.9.491.1.4.2.1.1.5 
 
   # This table lists the type, scale, and present value of a sensor listed in the Entity-MIB entPhysicalTable.
   - MIB: CISCO-ENTITY-SENSOR-MIB


### PR DESCRIPTION
Added FTD failover status MIB

Below are some reference details

- FTD failover status

  SNMP Obj Nav: [https://snmp.cloudapps.cisco.com/Support/SNMP/do/BrowseOID.do?local=en&translate=Translate&objectInput=1.3.6.1.4.1.9.9.491.1.4#oidContent
                 
 Specific OIDs that could helpful:

[601]  .1.3.6.1.4.1.9.9.491.1.4.2.1.1.1   CISCO-UNIFIED-FIREWALL-MIB::cufwFOGroupIndex

[602]  .1.3.6.1.4.1.9.9.491.1.4.2.1.1.2   CISCO-UNIFIED-FIREWALL-MIB::cufwFOGrpLastFailoverAt

[603]  .1.3.6.1.4.1.9.9.491.1.4.2.1.1.3   CISCO-UNIFIED-FIREWALL-MIB::cufwFOGrpHAstate

[604]  .1.3.6.1.4.1.9.9.491.1.4.2.1.1.4   CISCO-UNIFIED-FIREWALL-MIB::cufwFOGrpUpTime

[605]  .1.3.6.1.4.1.9.9.491.1.4.2.1.1.5   CISCO-UNIFIED-FIREWALL-MIB::cufwFOGrpContextCount