### PR TITLE
fixing duplicate enum in panditpud

### DIFF
--- a/profiles/kentik_snmp/panduit/panduit_pdu.yml
+++ b/profiles/kentik_snmp/panduit/panduit_pdu.yml
@@ -8,7 +8,7 @@ sysobjectid: 1.3.6.1.4.1.19536.10.*
 
 
 metrics:
-# Identity Table 
+# Identity Table
   - MIB: PANDUIT-MIB
     table:
       OID: 1.3.6.1.4.1.19536.10.1.1.2
@@ -30,14 +30,14 @@ metrics:
       - OID: 1.3.6.1.4.1.19536.10.1.1.2.1.11
         name: pdug5InputPhaseCount
       - OID: 1.3.6.1.4.1.19536.10.1.1.2.1.13
-        name: pdug5OutletCount   
+        name: pdug5OutletCount
       - OID: 1.3.6.1.4.1.19536.10.1.1.2.1.14
         name: pdug5MACAddress
       - OID: 1.3.6.1.4.1.19536.10.1.1.2.1.15
         name: pdug5IPv4Address
 
 
- # Input Table 
+ # Input Table
   - MIB: PANDUIT-MIB
     table:
       OID: 1.3.6.1.4.1.19536.10.1.2.1
@@ -67,7 +67,7 @@ metrics:
         name: pdug5InputPhasePowerVAR
 
 
-# Input Phases 
+# Input Phases
   - MIB: PANDUIT-MIB
     table:
       OID: 1.3.6.1.4.1.19536.10.1.2.2
@@ -101,7 +101,7 @@ metrics:
         enum:
           notApplicable: 0
           singlePhase: 1
-          phase1toN: 2 
+          phase1toN: 2
           phase2toN: 3
           phase3toN: 4
           phase1to2: 5
@@ -115,16 +115,16 @@ metrics:
         name:  pdug5GroupBreakerStatus
         enum:
           notApplicable: 0
-          notApplicable: 1
+          notApplicableA: 1
           breakerOn: 2
           breakerOff: 3
       - OID: 1.3.6.1.4.1.19536.10.1.3.1.1.2
-        name: pdug5GroupName 
+        name: pdug5GroupName
 
-# Environment 
+# Environment
 # Skip - I don't think there's any sensors plugged/enabled on these. Walking the OID tree shows them all as "disconnected"
 
-# Outlets 
+# Outlets
   - MIB: PANDUIT-MIB
     table:
       OID: 1.3.6.1.4.1.19536.10.1.5.1


### PR DESCRIPTION
Fixing a duplicate key issue in the pandit PDU enum:

```
           notApplicable: 0
-          notApplicable: 1
```