### PR TITLE
script to get correct cpu level

### DIFF
--- a/profiles/kentik_snmp/ubiquiti/unifi-access-point.yml
+++ b/profiles/kentik_snmp/ubiquiti/unifi-access-point.yml
@@ -13,7 +13,7 @@ provider: kentik-wap
 sysobjectid:
   - 1.3.6.1.4.1.41112  # Ubiquiti Networks, Inc.
   - 1.3.6.1.4.1.8072.3.2.10
-  
+
 metrics:
   - MIB: FROGFOOT-RESOURCES-MIB
     symbol:
@@ -36,6 +36,12 @@ metrics:
         name: loadValue
         poll_time_sec: 60
         tag: CPU
+         # This script converts the per mil results into a proper percentage for CPU
+        script: |
+          def main(n):
+            cpuim = n["CPU"]
+            n["CPU"] = cpuim / 100.
+            return None
     metric_tags:
       - column:
           OID: 1.3.6.1.4.1.10002.1.1.1.4.2.1.1
@@ -46,7 +52,7 @@ metrics:
           match_attributes:
             - "1 Minute Average"
   - MIB: UBNT-UniFi-MIB
-    table: 
+    table:
       OID: 1.3.6.1.4.1.41112.1.6.1.1
       name: unifiRadioTable
     symbols:


### PR DESCRIPTION
Closes #800 

Verified to get correct CPU values:

```
{
        "name": "kentik.snmp.CPU",
        "type": "gauge",
        "value": 1.08,
```