### PR TITLE
Recategorized specific OIDs related to Cisco

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-asa.yml
+++ b/profiles/kentik_snmp/cisco/cisco-asa.yml
@@ -5,7 +5,6 @@ extends:
 provider: kentik-firewall
 
 sysobjectid:
-
   - 1.3.6.1.4.1.9.1.227    # PIX Firewall
   - 1.3.6.1.4.1.9.1.389    # PIX 506
   - 1.3.6.1.4.1.9.1.390    # PIX 515

--- a/profiles/kentik_snmp/cisco/cisco-asa.yml
+++ b/profiles/kentik_snmp/cisco/cisco-asa.yml
@@ -5,6 +5,7 @@ extends:
 provider: kentik-firewall
 
 sysobjectid:
+
   - 1.3.6.1.4.1.9.1.227    # PIX Firewall
   - 1.3.6.1.4.1.9.1.389    # PIX 506
   - 1.3.6.1.4.1.9.1.390    # PIX 515
@@ -116,6 +117,9 @@ sysobjectid:
   - 1.3.6.1.4.1.9.1.1614    # ASA 1000V
   - 1.3.6.1.4.1.9.1.1617    # ASA 5585 NM8x10GE
   - 1.3.6.1.4.1.9.1.1618    # ASA 5585 NM4x10GE
+  - 1.3.6.1.4.1.9.1.1902    # Cisco VASA (Cisco Firepower Threat Defense, Version 6.7.0.2)
+  - 1.3.6.1.4.1.9.1.1903    # Cisco VASA System Context
+  - 1.3.6.1.4.1.9.1.1904    # Cisco VASA Security Context
   - 1.3.6.1.4.1.9.1.2114    # ASA 5506-X
   - 1.3.6.1.4.1.9.1.2115    # ASA 5506 SC
   - 1.3.6.1.4.1.9.1.2116    # ASA 5506 SY

--- a/profiles/kentik_snmp/cisco/cisco-firepower.yml
+++ b/profiles/kentik_snmp/cisco/cisco-firepower.yml
@@ -7,9 +7,6 @@ extends:
 provider: kentik-firepower
 
 sysobjectid:
-  - 1.3.6.1.4.1.9.1.1902    # Cisco VASA (Cisco Firepower Threat Defense, Version 6.7.0.2)
-  - 1.3.6.1.4.1.9.1.1903    # Cisco VASA System Context
-  - 1.3.6.1.4.1.9.1.1904    # Cisco VASA Security Context
   - 1.3.6.1.4.1.9.1.2285    # Firepower 9300 SA
   - 1.3.6.1.4.1.9.1.2286    # Firepower 9000 SM 24
   - 1.3.6.1.4.1.9.1.2288    # Firepower 9000 SM 36


### PR DESCRIPTION
Per @thezackm: the `cisco-products-mib` has [those] SysOIDs listed as a `ciscoVASA`, which way back when we had listed as a threat defense firewall