### PR TITLE
Adding metric to monitor Cisco AP Radio Admin up/down Status

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-all-devices.yml
+++ b/profiles/kentik_snmp/cisco/cisco-all-devices.yml
@@ -1147,29 +1147,6 @@ metrics:
           OID: 1.3.6.1.4.1.9.9.106.1.2.1.1.14
           conversion: hextoip
 
-  # A table of port entries. An entry will exist for each interface which support Authentication Framework feature.
-  - MIB: CISCO-AUTH-FRAMEWORK-MIB
-    table:
-      name: cafPortConfigTable
-      OID: 1.3.6.1.4.1.9.9.656.1.2.1
-    symbols:
-        # Specifies if reauthentication is enabled for this port.
-      - name: cafPortReauthEnabled
-        OID: 1.3.6.1.4.1.9.9.656.1.2.1.1.6
-        enum:
-          true: 1
-          false: 2
-        # Specifies the reauthentication interval, after which the port will be reauthenticated if value of the corresponding instance of cafPortReauthEnabled is 'true'
-      - name: cafPortReauthInterval
-        OID: 1.3.6.1.4.1.9.9.656.1.2.1.1.7
-    metric_tags:
-      # Indicates the session timeout used by Authentication Framework in the authentication session
-      - column:
-          name: cafSessionTimeout
-          OID: 1.3.6.1.4.1.9.9.656.1.4.1.1.15
-      - column: 
-          name: ifDescr
-          OID: 1.3.6.1.2.1.2.2.1.2
   - MIB: CISCO-NTP-MIB
     table:
       name: cntpPeersVarTable

--- a/profiles/kentik_snmp/cisco/cisco-all-devices.yml
+++ b/profiles/kentik_snmp/cisco/cisco-all-devices.yml
@@ -9,7 +9,6 @@
 # https://mibs.observium.org/mib/CISCO-ENVMON-MIB/
 # https://mibs.observium.org/mib/CISCO-RTTMON-MIB/
 # https://mibs.observium.org/mib/CISCO-POWER-ETHERNET-EXT-MIB/
-# https://mibs.observium.org/mib/CISCO-AUTH-FRAMEWORK-MIB/
 ---
 extends:
   - bgp4-mib.yml

--- a/profiles/kentik_snmp/cisco/cisco-wlc.yml
+++ b/profiles/kentik_snmp/cisco/cisco-wlc.yml
@@ -614,4 +614,3 @@ metric_tags:
       # This object specifies the AP's interface admin status.
       - name: cLApDot11IfAdminStatus
         OID: 1.3.6.1.4.1.9.9.513.1.2.1.1.14
-        

--- a/profiles/kentik_snmp/cisco/cisco-wlc.yml
+++ b/profiles/kentik_snmp/cisco/cisco-wlc.yml
@@ -3,6 +3,7 @@
 # https://mibs.observium.org/mib/AIRESPACE-SWITCHING-MIB/
 # https://mibs.observium.org/mib/AIRESPACE-WIRELESS-MIB/
 # https://mibs.observium.org/mib/CISCO-LWAPP-HA-MIB/
+# https://mibs.observium.org/mib/CISCO-LWAPP-AP-MIB/
 ---
 extends:
   - cisco-all-devices.yml
@@ -598,3 +599,14 @@ metric_tags:
   - column:
       name: agentInventoryProductVersion
       OID: 1.3.6.1.4.1.14179.1.1.1.14.0
+
+  # This table represents the information about the basic functional parameters corresponding to the dot11 interfaces of the APs that have joined the controller.
+  - MIB: CISCO-LWAPP-AP-MIB
+    table:
+      name: cLApDot11IfTable 
+      OID: 1.3.6.1.4.1.9.9.513.1.2.1
+    symbols:
+      # This object specifies the AP's interface admin status.
+      - name: cLApDot11IfAdminStatus
+        OID: 1.3.6.1.4.1.9.9.513.1.2.1.1.14
+        


### PR DESCRIPTION
This metric(cLApDot11IfAdminStatus) was updated via #812 but the metric is not available in New Relic. The MIB - CISCO-LWAPP-AP-MIB or the OID
1.3.6.1.4.1.9.9.513.1.2.1.1.14 are not being polled. Hence, re-adding it.