### PR TITLE
Add MikroTik SwOS SNMP Profile

### DIFF
--- a/profiles/kentik_snmp/mikrotik/mikrotik-switch.yml
+++ b/profiles/kentik_snmp/mikrotik/mikrotik-switch.yml
@@ -1,0 +1,138 @@
+extends:
+  - system-mib.yml
+  - if-mib.yml
+
+provider: kentik-switch
+sysobjectid:
+  - 1.3.6.1.4.1.14988.2.*    # Mikrotik SwOS
+
+metrics:
+  # Optical Table (SFP monitoring)
+  - MIB: MIKROTIK-MIB
+    table:
+      OID: 1.3.6.1.4.1.14988.1.1.19.1
+      name: mtxrOpticalTable
+      description: SFP information
+    symbols:
+      - OID: 1.3.6.1.4.1.14988.1.1.19.1.1.6
+        name: mtxrOpticalTemperature
+        description: Temperature of the SFP module
+      - OID: 1.3.6.1.4.1.14988.1.1.19.1.1.10
+        name: mtxrOpticalRxPower
+        description: Received signal power
+      - OID: 1.3.6.1.4.1.14988.1.1.19.1.1.9
+        name: mtxrOpticalTxPower
+        description: Transmit signal power
+      - OID: 1.3.6.1.4.1.14988.1.1.19.1.1.4
+        name: mtxrOpticalTxFault
+        enum:
+          "false": 0
+          "true": 1
+      - OID: 1.3.6.1.4.1.14988.1.1.19.1.1.3
+        name: mtxrOpticalRxLoss
+        enum:
+          "false": 0
+          "true": 1
+      - OID: 1.3.6.1.4.1.14988.1.1.19.1.1.7
+        name: mtxrOpticalSupplyVoltage
+      - OID: 1.3.6.1.4.1.14988.1.1.19.1.1.8
+        name: mtxrOpticalTxBiasCurrent
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.14988.1.1.19.1.1.2
+          name: mtxrOpticalName
+          description: Name of the SFP port
+
+  # Interface Metrics (switch SwOS specific)
+  - MIB: IF-MIB
+    table:
+      OID: 1.3.6.1.2.1.2.2
+      name: ifTable
+    symbols:
+      - OID: 1.3.6.1.2.1.31.1.1.1.6
+        name: ifHCInOctets
+        poll_time_sec: 60
+      - OID: 1.3.6.1.2.1.31.1.1.1.10
+        name: ifHCOutOctets
+        poll_time_sec: 60
+      - OID: 1.3.6.1.2.1.2.2.1.8
+        name: ifOperStatus
+        poll_time_sec: 60
+        enum:
+          up: 1
+          down: 2
+          testing: 3
+      - OID: 1.3.6.1.2.1.2.2.1.14
+        name: ifInErrors
+        poll_time_sec: 60
+      - OID: 1.3.6.1.2.1.2.2.1.20
+        name: ifOutErrors
+        poll_time_sec: 60
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.2.1.31.1.1.1.1
+          name: ifName
+      - column:
+          OID: 1.3.6.1.2.1.2.2.1.2
+          name: ifDescr
+      - column:
+          OID: 1.3.6.1.2.1.31.1.1.1.18
+          name: ifAlias
+
+  - MIB: IF-MIB
+    table:
+      OID: 1.3.6.1.2.1.2.2
+      name: ifTable
+    symbols:
+      - OID: 1.3.6.1.2.1.31.1.1.1.15
+        name: ifHighSpeed
+        poll_time_sec: 60
+        description: Interface speed in Mbps
+      - OID: 1.3.6.1.2.1.2.2.1.7
+        name: ifAdminStatus
+        poll_time_sec: 60
+        enum:
+          up: 1
+          down: 2
+          testing: 3
+      - OID: 1.3.6.1.2.1.31.1.1.1.7
+        name: ifHCInUcastPkts
+        poll_time_sec: 60
+      - OID: 1.3.6.1.2.1.31.1.1.1.11
+        name: ifHCOutUcastPkts
+        poll_time_sec: 60
+      - OID: 1.3.6.1.2.1.31.1.1.1.8
+        name: ifHCInMulticastPkts
+        poll_time_sec: 60
+      - OID: 1.3.6.1.2.1.31.1.1.1.12
+        name: ifHCOutMulticastPkts
+        poll_time_sec: 60
+      - OID: 1.3.6.1.2.1.31.1.1.1.9
+        name: ifHCInBroadcastPkts
+        poll_time_sec: 60
+      - OID: 1.3.6.1.2.1.31.1.1.1.13
+        name: ifHCOutBroadcastPkts
+        poll_time_sec: 60
+      # Adicionar contadores de descarte
+      - OID: 1.3.6.1.2.1.2.2.1.13
+        name: ifInDiscards
+        poll_time_sec: 60
+      - OID: 1.3.6.1.2.1.2.2.1.19
+        name: ifOutDiscards
+        poll_time_sec: 60
+
+  # Basic system
+  - MIB: SNMPv2-MIB
+    symbols:
+      - OID: 1.3.6.1.2.1.1.3.0
+        name: sysUpTime
+        poll_time_sec: 60
+      - OID: 1.3.6.1.2.1.1.4.0
+        name: sysContact
+        poll_time_sec: 300
+      - OID: 1.3.6.1.2.1.1.5.0
+        name: sysName
+        poll_time_sec: 300
+      - OID: 1.3.6.1.2.1.1.6.0
+        name: sysLocation
+        poll_time_sec: 300


### PR DESCRIPTION
This PR adds a new SNMP profile specifically designed for MikroTik SwOS devices. The current MikroTik profile in the repository is focused on RouterOS devices and doesn't properly capture all metrics available in SwOS-based switches.

The new profile includes correct metrics for switch SwOS:
- SFP monitoring metrics (temperature, Rx/Tx power, voltage, etc.)
- Enhanced interface statistics
  - High-capacity counters for octets and packets
  - Unicast, multicast, and broadcast packet counters
  - Interface errors and discards
  - Interface status and speed
- Basic system information

MikroTik SwOS-based switches have different SNMP OIDs and available metrics compared to RouterOS devices. This dedicated profile ensures proper monitoring of SwOS devices, including crucial metrics like SFP diagnostics that are essential for network monitoring.

## Testing
This profile has been tested with:
- MikroTik CSS326-24G-2S+
- SNMP v2c
- All metrics have been verified to report correctly
