### PR TITLE
Update cisco-asr.yml

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-asr.yml
+++ b/profiles/kentik_snmp/cisco/cisco-asr.yml
@@ -768,7 +768,7 @@ sysobjectid:
   - 1.3.6.1.4.1.9.1.2986    # NCS 540-12Z20G-SYS-D Router
   - 1.3.6.1.4.1.9.1.2987    # NCS 540X-12Z16G-SYS-A Router
   - 1.3.6.1.4.1.9.1.2988    # NCS 540X-12Z16G-SYS-D Router
-  - 1.3.6.1.4.1.9.1.2989    # C83001N1S6T
+  - 1.3.6.1.4.1.9.1.2989    # C83001N1S6T Router
   - 1.3.6.1.4.1.9.1.3001    # NCS 540-FH-CSR-SYS Router
   - 1.3.6.1.4.1.9.1.3002    # NCS 540-FH-AGG-SYS Router
   - 1.3.6.1.4.1.9.1.3009    # NCS 540 Router


### PR DESCRIPTION
It seems the build failed with #823 . I'm doing a dummy commit to re-push the changes in the cisco-asr file as Ktranslate is unable to identify the C8300 routers after restarting the Kentik container.