### PR TITLE
[FIX] Changed formatting of `cempMemPoolTable` metric_tags

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-asa.yml
+++ b/profiles/kentik_snmp/cisco/cisco-asa.yml
@@ -218,19 +218,21 @@ metrics:
           OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.3
           name: cempMemPoolName
       # Indicates the number of bytes from the memory pool that are currently in use by applications on the managed device.
-      - name: cempMemPoolUsed
-        OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.7
-        poll_time_sec: 60
-        tag: MemoryUsed
-        allow_duplicate: true
-        condition: cempMemPoolType=10
+      - column:
+          name: cempMemPoolUsed
+          OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.7
+          poll_time_sec: 60
+          tag: MemoryUsed
+          allow_duplicate: true
+          condition: cempMemPoolType=10
         # Indicates the number of bytes from the memory pool that are currently unused on the managed device.
-      - name: cempMemPoolFree
-        OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.8
-        poll_time_sec: 60
-        tag: MemoryFree
-        allow_duplicate: true
-        condition: cempMemPoolType=10
+      - column:
+          name: cempMemPoolFree
+          OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.8
+          poll_time_sec: 60
+          tag: MemoryFree
+          allow_duplicate: true
+          condition: cempMemPoolType=10
   - MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
     symbols:
       - OID: 1.3.6.1.4.1.9.9.392.1.4.1.2.0


### PR DESCRIPTION
Tweaked the profile as recommended by Kentik Support (ticket `#11137`) and confirmed that data for `cempMemPoolFree` and `cempMemPoolUsed` started ingesting

<img width="1588" alt="Screenshot 2025-02-05 at 12 17 56 PM" src="https://github.com/user-attachments/assets/46b2c33c-ea53-4bde-bb80-9649088ebbce" />
