### PR TITLE
Update cisco-catalyst.yml with new OIDs captured

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-catalyst.yml
+++ b/profiles/kentik_snmp/cisco/cisco-catalyst.yml
@@ -400,6 +400,9 @@ sysobjectid:
   - 1.3.6.1.4.1.9.1.3164    # Catalyst 9200CX-12P-2XGH
   - 1.3.6.1.4.1.9.1.3195    # Catalyst 9200CX-8P-2XGH
   - 1.3.6.1.4.1.9.1.3196    # Catalyst 9200CX-8UXG-2XH
+  - 1.3.6.1.4.1.9.1.2573    # Catalyst 9500-24Y4C
+  - 1.3.6.1.4.1.9.1.2567    # Catalyst 9500-32QC
+  - 1.3.6.1.4.1.9.1.2990    # Catalyst C8300-1N1S-4T2X
   - 1.3.6.1.4.1.9.6.1.83.10.1    # SG300-10 Managed Switch
   - 1.3.6.1.4.1.9.6.1.83.52.2    # SG300-52P Managed Switch
   - 1.3.6.1.4.1.9.12.3.1.3.843    # MDS 9148 Multilayer Fabric Switch


### PR DESCRIPTION
Updated the three below OIDs

  - 1.3.6.1.4.1.9.1.2573    # Catalyst 9500-24Y4C
  - 1.3.6.1.4.1.9.1.2567    # Catalyst 9500-32QC
  - 1.3.6.1.4.1.9.1.2990    # Catalyst C8300-1N1S-4T2X