### PR TITLE
Adding HPE Single Phase 1Gb UPS Network Management Module SNMP profile

### DIFF
--- a/profiles/kentik_snmp/hpe/hpe-cambium.yml
+++ b/profiles/kentik_snmp/hpe/hpe-cambium.yml
@@ -1,0 +1,81 @@
+# HPE Single Phase 1Gb UPS Network Management Module SNMP profile
+# Product Info: https://support.hpe.com
+# MIB reference: Currently based on SNMP walk, not official MIB.
+
+---
+
+extends:
+  - system-mib.yml
+  - ups-mib.yml
+
+provider: kentik-ups
+
+sysobjectid:
+  - 1.3.6.1.4.1.232.165.*  # Adjust this if you find a more accurate base sysOID for your device
+
+# OPTIONAL sysDescr match examples (you can remove if unnecessary)
+matches:
+  "^hpe single phase": hpe-ups.yml
+
+metrics:
+  - MIB: HPE-UPS  # Placeholder for the MIB name
+    symbol:
+      name: batteryChargePercent
+      OID: 1.3.6.1.4.1.232.165.3.2.1.0
+      poll_time_sec: 60
+      description: "Battery charge percentage"
+
+  - MIB: HPE-UPS
+    symbol:
+      name: batteryVoltage
+      OID: 1.3.6.1.4.1.232.165.3.2.2.0
+      poll_time_sec: 60
+      description: "Battery voltage in volts"
+
+  - MIB: HPE-UPS
+    symbol:
+      name: onBattery
+      OID: 1.3.6.1.4.1.232.165.3.2.3.0
+      description: "Running on battery: 0 = No, 1 = Yes"
+      enum:
+        no: 0
+        yes: 1
+
+  - MIB: HPE-UPS
+    symbol:
+      name: estimatedRuntime
+      OID: 1.3.6.1.4.1.232.165.3.2.4.0
+      description: "Estimated runtime remaining (seconds)"
+
+  - MIB: HPE-UPS
+    symbol:
+      name: loadPercent
+      OID: 1.3.6.1.4.1.232.165.3.2.5.0
+      description: "Current UPS load as a percentage"
+
+  - MIB: HPE-UPS
+    symbol:
+      name: batteryTemperatureC
+      OID: 1.3.6.1.4.1.232.165.3.3.1.0
+      description: "Battery temperature in tenths of °C (e.g., 599 = 59.9°C). Convert to °F in dashboards."
+
+  - MIB: SNMPv2-MIB
+    symbol:
+      name: sysDescr
+      OID: 1.3.6.1.2.1.1.1.0
+      description: "System Description"
+
+  - MIB: SNMPv2-MIB
+    symbol:
+      name: sysUpTime
+      OID: 1.3.6.1.2.1.1.3.0
+      description: "System Uptime"
+
+  - MIB: SNMPv2-MIB
+    symbol:
+      name: sysLocation
+      OID: 1.3.6.1.2.1.1.6.0
+      description: "System Location"
+
+# You can tag your metrics here using static or tabular tag OIDs if needed
+metric_tags: []


### PR DESCRIPTION
Closes #844 

Adding in 

HPE Single Phase 1Gb UPS Network Management Module SNMP profile
Product Info: https://support.hpe.com
MIB reference: Currently based on SNMP walk, not official MIB.