### PR TITLE
Fixing a miss match in how admin and opr status work

### DIFF
--- a/profiles/kentik_snmp/_general/if-mib.yml
+++ b/profiles/kentik_snmp/_general/if-mib.yml
@@ -60,6 +60,8 @@ metrics:
       - name: ifAdminStatus
         OID: 1.3.6.1.2.1.2.2.1.7
         tag: if_AdminStatus
+        poll_time_sec: 60
+        format: gauge
         enum:
           up: 1
           down: 2
@@ -69,6 +71,7 @@ metrics:
         OID: 1.3.6.1.2.1.2.2.1.8
         poll_time_sec: 60
         tag: if_OperStatus
+        format: gauge
         enum:
           up: 1
           down: 2


### PR DESCRIPTION
I think this will fix https://github.com/kentik/ktranslate/issues/827