### PR TITLE
Fix: remove generic linux sysoid from unifi-access-point.yml

### DIFF
--- a/profiles/kentik_snmp/ubiquiti/unifi-access-point.yml
+++ b/profiles/kentik_snmp/ubiquiti/unifi-access-point.yml
@@ -12,7 +12,7 @@ provider: kentik-wap
 
 sysobjectid:
   - 1.3.6.1.4.1.41112  # Ubiquiti Networks, Inc.
-
+  - 1.3.6.1.4.1.8072.3.2.10.ubiquiti    # Generic Ubiquiti Device
 metrics:
   - MIB: FROGFOOT-RESOURCES-MIB
     symbol:


### PR DESCRIPTION
I'd seen this before but never got around to fixing it.  Running an Ubuntu test machine and its getting picked up as a unifi access point which is not correct.

If unifi gear does happen to use the generic sysoid then the burden should be for their users to manually set a profile instead of causing a confusing mix up.