### PR TITLE
Fix: typo in metric name

### DIFF
--- a/profiles/kentik_snmp/vertiv/vertiv-ups.yml
+++ b/profiles/kentik_snmp/vertiv/vertiv-ups.yml
@@ -66,7 +66,7 @@ metrics:
         name: lgpPwrBatteryTimeRemaining
       # The present percentage of battery capacity.
       - OID: 1.3.6.1.4.1.476.1.42.3.5.1.19.0
-        name: gpPwrBatteryCapacity	
+        name: lgpPwrBatteryCapacity	
       # The date and time when the battery system was put into service. This information persists across system reboot events. It is the responsibility of Service to reset this date/time when the batteries are replaced. The date and time are determined in seconds since the epoch on January 1, 1970.
       - OID: 1.3.6.1.4.1.476.1.42.3.5.1.24.0
         name: lgpPwrBatteryLastCommissionTime


### PR DESCRIPTION
Copy paste missed the first character of this metric name