### PR TITLE
Fix: Adjustment to cNTP table

### DIFF
--- a/profiles/kentik_snmp/cisco/cisco-all-devices.yml
+++ b/profiles/kentik_snmp/cisco/cisco-all-devices.yml
@@ -1162,14 +1162,14 @@ metrics:
     table:
       name: cntpPeersVarTable
       OID: 1.3.6.1.4.1.9.9.168.1.2.1
-    symbols:
-      - name: cntpPeersRefId
-        OID: 1.3.6.1.4.1.9.9.168.1.2.1.1.15
-        conversion: hextoip
-      - name: cntpPeersStratum
-        OID: 1.3.6.1.4.1.9.9.168.1.2.1.1.9
+    symbols: 
+      - name: cntpPeersRootDelay
+        OID: 1.3.6.1.4.1.9.9.168.1.2.1.1.13
     metric_tags:
       - column:
-          name: cntpPeersPeerName
-          OID: 1.3.6.1.4.1.9.9.168.1.2.1.1.31
+          name: cntpPeersPeerAddress
+          OID: 1.3.6.1.4.1.9.9.168.1.2.1.1.3
           conversion: hextoip
+      - column:
+          name: cntpPeersStratum
+          OID: 1.3.6.1.4.1.9.9.168.1.2.1.1.9


### PR DESCRIPTION
previously the chosen metrics didn't make sense as a monitoring/performance data point, it was all just architectural relationships. I've added the time delay as the metric and move the other values to metric tags