### PR TITLE
Document pointing ktranslate at a fork via profile_git_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
 # ktranslate-profiles
 This repo contains configuration files that define how KTranslate polls information from specific network devices. [This tutorial](https://github.com/kentik/ktranslate/wiki/Tutorial:-Writing-a-custom-yaml-file-for-SNMP) contains more information about how to create an SNMP profile for a new device type. You can also check out this heavily commented [template profile](https://github.com/kentik/snmp-profiles/blob/main/profiles/kentik_snmp/_template.yml) for examples of the fields and configurations you can include in your profiles.  
 
-## NOTE: This repo is no longer actively creating new profiles based on requests in issues. We will accept pull requests from the community for new profiles but cannot create any more ourselves. 
+## NOTE: This repo is no longer actively creating new profiles based on requests in issues. We will accept pull requests from the community for new profiles but cannot create any more ourselves.
+
+## Using a fork with ktranslate
+
+ktranslate ships this repository's `profiles/` tree in the Docker image. To run a **fork** (or a private copy) without rebuilding the image, set these keys in the `global` section of `snmp-base.yaml`:
+
+```yaml
+global:
+  profile_git_url: https://github.com/YOU/snmp-profiles
+  profile_git_commit: ""   # optional SHA; omit to use HEAD of the cloned branch
+```
+
+ktranslate clones that URL at process start. Keep the upstream layout (`profiles/kentik_snmp/<vendor>/*.yml`). Private repos need `KT_GIT_ACCESS_USERNAME` / `KT_GIT_ACCESS_TOKEN`; a non-default branch uses `KT_GIT_PULL_BRANCH`.
+
+Full details: [Loading SNMP profiles from Git](https://github.com/kentik/ktranslate/wiki/Advanced-Ktranslate-Configuration#loading-snmp-profiles-from-git) on the ktranslate wiki.
+


### PR DESCRIPTION
## Summary
- README: how to run a fork of this repo with ktranslate `profile_git_url` (no image rebuild)
- Links to the ktranslate wiki section: https://github.com/kentik/ktranslate/wiki/Advanced-Ktranslate-Configuration#loading-snmp-profiles-from-git

## Test plan
- [ ] README renders on https://github.com/kentik/snmp-profiles
- [ ] Wiki link opens the Git profiles section
