### PR TITLE
Add Aruba ProVision chassis sensors (hpicfSensorTable)

### DIFF
--- a/profiles/kentik_snmp/aruba/aruba-switch.yml
+++ b/profiles/kentik_snmp/aruba/aruba-switch.yml
@@ -1,6 +1,7 @@
 # http://www.circitor.fr/Mibs/Html/S/STATISTICS-MIB.php
 # https://mibs.observium.org/mib/NETSWITCH-MIB/
 # https://mibs.observium.org/mib/POWER-ETHERNET-MIB/
+# https://mibs.observium.org/mib/HP-ICF-CHASSIS/
 ---
 extends:
   - if-mib.yml
@@ -210,3 +211,26 @@ metrics:
       - column:
           OID: 1.3.6.1.2.1.105.1.3.1.1.1
           name: pethMainPseGroupIndex
+  # Chassis sensors (fan/temp/PSU status) — INDEX hpicfSensorIndex
+  - MIB: HP-ICF-CHASSIS
+    table:
+      name: hpicfSensorTable
+      OID: 1.3.6.1.4.1.11.2.14.11.1.2.6
+    symbols:
+      - name: hpicfSensorStatus
+        OID: 1.3.6.1.4.1.11.2.14.11.1.2.6.1.4
+        enum:
+          unknown: 1
+          bad: 2
+          warning: 3
+          good: 4
+          notPresent: 5
+    metric_tags:
+      - column:
+          name: hpicfSensorDescr
+          OID: 1.3.6.1.4.1.11.2.14.11.1.2.6.1.7
+        tag: sensor_name
+      - column:
+          name: hpicfSensorNumber
+          OID: 1.3.6.1.4.1.11.2.14.11.1.2.6.1.3
+        tag: sensor_number


### PR DESCRIPTION
## Summary
- Add `HP-ICF-CHASSIS::hpicfSensorTable` to the Aruba ProVision / ProCurve profile (`aruba-switch.yml`).
- Same chassis sensor table as ICF; this profile does not extend `hp-icf-switch.yml`, so it needs its own copy. OIDs from the published MIB.

## Test plan
- [ ] YAML loads
- [ ] Physical 2930/3810/ProVision switch returns `hpicfSensorStatus` rows
- [ ] No poller errors when a sensor is `notPresent`
