### PR TITLE
Add Netgear switch chassis sensors (boxServices)

### DIFF
--- a/profiles/kentik_snmp/netgear/netgear-switch.yml
+++ b/profiles/kentik_snmp/netgear/netgear-switch.yml
@@ -1,4 +1,5 @@
 # https://github.com/librenms/librenms/blob/master/mibs/netgear/NETGEAR-SWITCHING-MIB
+# https://mibs.observium.org/mib/NETGEAR-BOXSERVICES-PRIVATE-MIB/
 ---
 
 extends:
@@ -34,6 +35,84 @@ metrics:
       poll_time_sec: 60
       tag: CPU
       conversion: "regexp:60 Secs.*?(\\d+)"
+  # Chassis fans — INDEX boxServicesFansIndex
+  - MIB: NETGEAR-BOXSERVICES-PRIVATE-MIB
+    table:
+      name: boxServicesFansTable
+      OID: 1.3.6.1.4.1.4526.10.43.1.6
+    symbols:
+      - name: boxServicesFanItemState
+        OID: 1.3.6.1.4.1.4526.10.43.1.6.1.3
+        enum:
+          notpresent: 1
+          operational: 2
+          failed: 3
+          powering: 4
+          nopower: 5
+          notpowering: 6
+          incompatible: 7
+    metric_tags:
+      - column:
+          name: boxServicesFansIndex
+          OID: 1.3.6.1.4.1.4526.10.43.1.6.1.1
+        tag: fan_index
+      - column:
+          name: boxServicesFanUnitIndex
+          OID: 1.3.6.1.4.1.4526.10.43.1.6.1.6
+        tag: unit_index
+  # Chassis power supplies — INDEX boxServicesPowSupplyIndex
+  - MIB: NETGEAR-BOXSERVICES-PRIVATE-MIB
+    table:
+      name: boxServicesPowSuppliesTable
+      OID: 1.3.6.1.4.1.4526.10.43.1.7
+    symbols:
+      - name: boxServicesPowSupplyItemState
+        OID: 1.3.6.1.4.1.4526.10.43.1.7.1.3
+        enum:
+          notpresent: 1
+          operational: 2
+          failed: 3
+          powering: 4
+          nopower: 5
+          notpowering: 6
+          incompatible: 7
+    metric_tags:
+      - column:
+          name: boxServicesPowSupplyIndex
+          OID: 1.3.6.1.4.1.4526.10.43.1.7.1.1
+        tag: psu_index
+      - column:
+          name: boxServicesPowerSuppUnitIndex
+          OID: 1.3.6.1.4.1.4526.10.43.1.7.1.4
+        tag: unit_index
+  # Chassis temperature — INDEX boxServicesUnitIndex, boxServicesTempSensorIndex
+  - MIB: NETGEAR-BOXSERVICES-PRIVATE-MIB
+    table:
+      name: boxServicesTempSensorsTable
+      OID: 1.3.6.1.4.1.4526.10.43.1.8
+    symbols:
+      - name: boxServicesTempSensorState
+        OID: 1.3.6.1.4.1.4526.10.43.1.8.1.4
+        enum:
+          low: 0
+          normal: 1
+          warning: 2
+          critical: 3
+          shutdown: 4
+          notpresent: 5
+          notoperational: 6
+      - name: boxServicesTempSensorTemperature
+        OID: 1.3.6.1.4.1.4526.10.43.1.8.1.5
+        tag: Temperature
+    metric_tags:
+      - column:
+          name: boxServicesUnitIndex
+          OID: 1.3.6.1.4.1.4526.10.43.1.8.1.1
+        tag: unit_index
+      - column:
+          name: boxServicesTempSensorIndex
+          OID: 1.3.6.1.4.1.4526.10.43.1.8.1.2
+        tag: temp_index
 metric_tags:
   # The switch's Machine Model.
   - column:


### PR DESCRIPTION
## Summary
- Add `NETGEAR-BOXSERVICES-PRIVATE-MIB` fan, PSU, and temperature tables to `netgear-switch.yml` (M4300 / FASTPATH `4526.10`).
- Temperature uses the two-column INDEX (`unit` + `sensor`). Fan speed is a DisplayString in this MIB, so only `boxServicesFanItemState` is polled.

## Test plan
- [ ] YAML loads
- [ ] M4300 returns fan state / PSU state / `Temperature`
- [ ] Fan speed OID left out (OctetString, not RPM)
