### PR TITLE
Add Juniper operating-table temperature and state

### DIFF
--- a/profiles/kentik_snmp/juniper/juniper-all-devices.yml
+++ b/profiles/kentik_snmp/juniper/juniper-all-devices.yml
@@ -24,11 +24,28 @@ metrics:
         name: jnxOperatingBuffer
         poll_time_sec: 60
         tag: MemoryUtilization
+      # Celsius; 0 means unavailable or inapplicable.
+      - OID: 1.3.6.1.4.1.2636.3.1.13.1.7
+        name: jnxOperatingTemp
+        tag: Temperature
+      - OID: 1.3.6.1.4.1.2636.3.1.13.1.6
+        name: jnxOperatingState
+        enum:
+          unknown: 1
+          running: 2
+          ready: 3
+          reset: 4
+          runningAtFullSpeed: 5
+          down: 6
+          standby: 7
     metric_tags:
       - tag: chassis
         column:
           OID: 1.3.6.1.4.1.2636.3.1.13.1.18
           name: jnxOperatingChassisDescr
+      - column:
+          OID: 1.3.6.1.4.1.2636.3.1.13.1.5
+          name: jnxOperatingDescr
 
   - MIB: JUNIPER-MIB
     table:


### PR DESCRIPTION
## Summary
- Add `jnxOperatingTemp` (`Temperature`) and `jnxOperatingState` to the existing `jnxOperatingEntry` scrape in `juniper-all-devices.yml`.
- Tag series with `jnxOperatingDescr` so RE/FPC/fan rows have names (today only `jnxOperatingChassisDescr`).
- Complements existing `jnxFruTemp` / `jnxFruState`. Temperature `0` means N/A.

## Test plan
- [ ] YAML loads
- [ ] MX/EX/QFX/SRX return per-component `Temperature` and operating state
- [ ] Child profiles that extend this file inherit the new columns
